### PR TITLE
feat: Add route groups with middleware support

### DIFF
--- a/Group.go
+++ b/Group.go
@@ -4,23 +4,35 @@ import (
 	"path"
 )
 
-// Group represents a route group with a common prefix and middleware
+// Group represents a route group with a common prefix and middleware.
+// This allows organizing routes under a common URL prefix (e.g., /api/v1)
+// and applying middleware that only affects routes within this group.
+// Groups can be nested to create hierarchical route structures.
 type Group struct {
+	// prefix is the URL path prefix for all routes in this group
 	prefix   string
+	// server is a reference to the main server instance for route registration
 	server   *Server
+	// handlers contains middleware functions that will be applied to all routes in this group
 	handlers []Handler
 }
 
-// Group creates a sub-group with additional prefix and optional middleware
+// Group creates a sub-group with additional prefix and optional middleware.
+// The new group inherits all middleware from the parent group and can add its own.
+// Example: apiGroup.Group("/users", authMiddleware) creates /api/users with auth.
 func (g *Group) Group(prefix string, handlers ...Handler) *Group {
 	return &Group{
+		// Combine parent and child prefixes using path.Join for proper URL construction
 		prefix:   path.Join(g.prefix, prefix),
 		server:   g.server,
+		// Inherit parent middleware and append any new middleware
 		handlers: append(g.handlers, handlers...),
 	}
 }
 
-// Use adds middleware to the group
+// Use adds middleware to the group.
+// These middleware functions will be executed for all routes registered after this call.
+// Middleware is executed in the order it was added.
 func (g *Group) Use(handlers ...Handler) {
 	g.handlers = append(g.handlers, handlers...)
 }
@@ -70,41 +82,58 @@ func (g *Group) Trace(path string, handler Handler) {
 	g.addRoute("TRACE", path, handler)
 }
 
-// StaticFiles serves static files with the group prefix
+// StaticFiles serves static files with the group prefix.
+// reqDir is the URL path relative to the group prefix.
+// targetDir is the local filesystem directory containing the files.
+// nbrOfTokensToStrip removes URL path segments when mapping to filesystem paths.
 func (g *Group) StaticFiles(reqDir string, targetDir string, nbrOfTokensToStrip int) {
 	fullPath := path.Join(g.prefix, reqDir)
 	g.server.StaticFiles(fullPath, targetDir, nbrOfTokensToStrip)
 }
 
-// Proxy sets up a reverse proxy with the group prefix
+// Proxy sets up a reverse proxy with the group prefix.
+// pathPrefix is the URL path relative to the group prefix.
+// targetURL is the backend server URL to proxy requests to.
+// prefixTokensToRemove strips URL segments before forwarding the request.
 func (g *Group) Proxy(pathPrefix string, targetURL string, prefixTokensToRemove int) error {
 	fullPath := path.Join(g.prefix, pathPrefix)
 	return g.server.Proxy(fullPath, targetURL, prefixTokensToRemove)
 }
 
-// SSEHandler returns a handler that sets up Server-Sent Events with the group prefix
+// SSEHandler returns a handler that sets up Server-Sent Events with the group prefix.
+// Note: The group prefix doesn't affect the SSE handler itself, but the route
+// it's registered on will include the group prefix.
 func (g *Group) SSEHandler(eventsChan <-chan any, eventName ...string) Handler {
 	return g.server.SSEHandler(eventsChan, eventName...)
 }
 
-// addRoute is a helper that adds a route with the group prefix and middleware
+// addRoute is a helper that adds a route with the group prefix and middleware.
+// It constructs the full path by combining the group prefix with the route path,
+// then wraps the handler with all group middleware before registering it.
 func (g *Group) addRoute(method, routePath string, handler Handler) {
+	// Construct the full URL path by joining group prefix and route path
+	// The leading "/" ensures proper path formatting
 	fullPath := path.Join("/", g.prefix, routePath)
 	
-	// Build the middleware chain
+	// Build the middleware chain - start with the route handler as the final handler
 	finalHandler := handler
 	
-	// Wrap in reverse order so they execute in the order they were added
+	// Wrap handlers in reverse order to ensure they execute in the order they were added.
+	// This creates a chain where each middleware wraps the next one.
 	for i := len(g.handlers) - 1; i >= 0; i-- {
-		// Capture the middleware and next handler in the closure
+		// Capture the current middleware and next handler in the closure
+		// to avoid closure variable issues in the loop
 		middleware := g.handlers[i]
 		nextHandler := finalHandler
 		
 		finalHandler = func(ctx Context) error {
-			// Track if Next() was called
+			// Track whether the middleware called Next() to continue the chain.
+			// This allows middleware to optionally stop the chain (e.g., for auth failures)
 			nextCalled := false
 			
-			// Create a wrapper that tracks Next() calls
+			// Create a context wrapper that intercepts Next() calls.
+			// This allows us to track when middleware explicitly passes control
+			// to the next handler in the chain.
 			wrapper := &contextWrapper{
 				Context: ctx,
 				next: func() error {
@@ -113,10 +142,12 @@ func (g *Group) addRoute(method, routePath string, handler Handler) {
 				},
 			}
 			
-			// Execute the middleware with our wrapper
+			// Execute the middleware with our wrapper context
 			err := middleware(wrapper)
 			
-			// If middleware didn't call Next() and no error, call next handler
+			// If middleware didn't call Next() and didn't return an error,
+			// automatically continue to the next handler.
+			// This allows middleware to work without explicitly calling Next().
 			if err == nil && !nextCalled {
 				err = nextHandler(ctx)
 			}
@@ -128,13 +159,19 @@ func (g *Group) addRoute(method, routePath string, handler Handler) {
 	g.server.AddMethod(method, fullPath, finalHandler)
 }
 
-// contextWrapper wraps a Context to intercept Next() calls
+// contextWrapper wraps a Context to intercept Next() calls.
+// This allows group middleware to properly track and control the execution chain,
+// ensuring that middleware can stop the chain or pass control as needed.
 type contextWrapper struct {
+	// Embedded Context provides all standard context methods
 	Context
+	// next is our custom Next() implementation that tracks calls
 	next func() error
 }
 
-// Next overrides the Context's Next method
+// Next overrides the Context's Next method to use our custom implementation.
+// This allows the group to track when middleware explicitly passes control
+// to the next handler in the chain.
 func (w *contextWrapper) Next() error {
 	return w.next()
 }

--- a/Group.go
+++ b/Group.go
@@ -1,0 +1,140 @@
+package rweb
+
+import (
+	"path"
+)
+
+// Group represents a route group with a common prefix and middleware
+type Group struct {
+	prefix   string
+	server   *Server
+	handlers []Handler
+}
+
+// Group creates a sub-group with additional prefix and optional middleware
+func (g *Group) Group(prefix string, handlers ...Handler) *Group {
+	return &Group{
+		prefix:   path.Join(g.prefix, prefix),
+		server:   g.server,
+		handlers: append(g.handlers, handlers...),
+	}
+}
+
+// Use adds middleware to the group
+func (g *Group) Use(handlers ...Handler) {
+	g.handlers = append(g.handlers, handlers...)
+}
+
+// Get registers a GET route with the group prefix
+func (g *Group) Get(path string, handler Handler) {
+	g.addRoute("GET", path, handler)
+}
+
+// Post registers a POST route with the group prefix
+func (g *Group) Post(path string, handler Handler) {
+	g.addRoute("POST", path, handler)
+}
+
+// Put registers a PUT route with the group prefix
+func (g *Group) Put(path string, handler Handler) {
+	g.addRoute("PUT", path, handler)
+}
+
+// Patch registers a PATCH route with the group prefix
+func (g *Group) Patch(path string, handler Handler) {
+	g.addRoute("PATCH", path, handler)
+}
+
+// Delete registers a DELETE route with the group prefix
+func (g *Group) Delete(path string, handler Handler) {
+	g.addRoute("DELETE", path, handler)
+}
+
+// Head registers a HEAD route with the group prefix
+func (g *Group) Head(path string, handler Handler) {
+	g.addRoute("HEAD", path, handler)
+}
+
+// Options registers an OPTIONS route with the group prefix
+func (g *Group) Options(path string, handler Handler) {
+	g.addRoute("OPTIONS", path, handler)
+}
+
+// Connect registers a CONNECT route with the group prefix
+func (g *Group) Connect(path string, handler Handler) {
+	g.addRoute("CONNECT", path, handler)
+}
+
+// Trace registers a TRACE route with the group prefix
+func (g *Group) Trace(path string, handler Handler) {
+	g.addRoute("TRACE", path, handler)
+}
+
+// StaticFiles serves static files with the group prefix
+func (g *Group) StaticFiles(reqDir string, targetDir string, nbrOfTokensToStrip int) {
+	fullPath := path.Join(g.prefix, reqDir)
+	g.server.StaticFiles(fullPath, targetDir, nbrOfTokensToStrip)
+}
+
+// Proxy sets up a reverse proxy with the group prefix
+func (g *Group) Proxy(pathPrefix string, targetURL string, prefixTokensToRemove int) error {
+	fullPath := path.Join(g.prefix, pathPrefix)
+	return g.server.Proxy(fullPath, targetURL, prefixTokensToRemove)
+}
+
+// SSEHandler returns a handler that sets up Server-Sent Events with the group prefix
+func (g *Group) SSEHandler(eventsChan <-chan any, eventName ...string) Handler {
+	return g.server.SSEHandler(eventsChan, eventName...)
+}
+
+// addRoute is a helper that adds a route with the group prefix and middleware
+func (g *Group) addRoute(method, routePath string, handler Handler) {
+	fullPath := path.Join("/", g.prefix, routePath)
+	
+	// Build the middleware chain
+	finalHandler := handler
+	
+	// Wrap in reverse order so they execute in the order they were added
+	for i := len(g.handlers) - 1; i >= 0; i-- {
+		// Capture the middleware and next handler in the closure
+		middleware := g.handlers[i]
+		nextHandler := finalHandler
+		
+		finalHandler = func(ctx Context) error {
+			// Track if Next() was called
+			nextCalled := false
+			
+			// Create a wrapper that tracks Next() calls
+			wrapper := &contextWrapper{
+				Context: ctx,
+				next: func() error {
+					nextCalled = true
+					return nextHandler(ctx)
+				},
+			}
+			
+			// Execute the middleware with our wrapper
+			err := middleware(wrapper)
+			
+			// If middleware didn't call Next() and no error, call next handler
+			if err == nil && !nextCalled {
+				err = nextHandler(ctx)
+			}
+			
+			return err
+		}
+	}
+	
+	g.server.AddMethod(method, fullPath, finalHandler)
+}
+
+// contextWrapper wraps a Context to intercept Next() calls
+type contextWrapper struct {
+	Context
+	next func() error
+}
+
+// Next overrides the Context's Next method
+func (w *contextWrapper) Next() error {
+	return w.next()
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Thanks and credit to Akyoto, especially for the radix tree!
 - Server Sent Events
 - Flexible static files handling
 - Scales incredibly well with the number of routes
+- Route grouping with middleware support
 
 ## Installation
 
@@ -184,6 +185,33 @@ func main() {
 	log.Fatal(s.Run())
 }
 ```
+
+## Route Groups
+
+Route groups allow you to organize routes with common prefixes and apply middleware to specific sets of routes:
+
+```go
+// Basic group
+api := s.Group("/api")
+api.Get("/users", getUsersHandler)
+api.Post("/users", createUserHandler)
+
+// Group with middleware
+admin := s.Group("/admin", authMiddleware, loggerMiddleware)
+admin.Get("/dashboard", dashboardHandler)
+admin.Delete("/users/:id", deleteUserHandler)
+
+// Nested groups
+v1 := api.Group("/v1")
+v1.Get("/status", statusHandler)  // Available at /api/v1/status
+
+// Add middleware after group creation
+v2 := api.Group("/v2")
+v2.Use(rateLimiterMiddleware)
+v2.Get("/users", v2UsersHandler)
+```
+
+Groups support all HTTP methods (`Get`, `Post`, `Put`, `Patch`, `Delete`, `Head`, `Options`, `Connect`, `Trace`) as well as `StaticFiles` and `Proxy`.
 
 ## Tests
 

--- a/Server.go
+++ b/Server.go
@@ -183,13 +183,19 @@ func (s *Server) SetupSSE(ctx Context, eventChan <-chan any, eventName string) e
 	return ctx.SetSSE(eventChan, eventName)
 }
 
-// SSEHandler returns a handler that sets up Server-Sent Events
+// SSEHandler returns a handler that sets up Server-Sent Events.
+// This is a convenience method that creates a handler function for SSE endpoints.
+// The eventsChan parameter is the channel from which events will be sent to the client.
+// The optional eventName parameter specifies the event type (defaults to "message").
+// Usage: s.Get("/events", s.SSEHandler(eventsChan, "update"))
 func (s *Server) SSEHandler(eventsChan <-chan any, eventName ...string) Handler {
+	// Default to "message" event type if not specified
 	name := "message" // default event name
 	if len(eventName) > 0 && eventName[0] != "" {
 		name = eventName[0]
 	}
 	
+	// Return a handler that sets up SSE for the given context
 	return func(ctx Context) error {
 		return s.SetupSSE(ctx, eventsChan, name)
 	}
@@ -492,7 +498,12 @@ func (s *Server) Use(handlers ...Handler) {
 	s.handlers = append(s.handlers, last) // add back the last
 }
 
-// Group creates a new route group with the given prefix and optional middleware
+// Group creates a new route group with the given prefix and optional middleware.
+// Groups allow organizing routes under a common URL prefix and applying middleware
+// that only affects routes within the group.
+// Example: api := s.Group("/api", authMiddleware) creates a group where all routes
+// will be prefixed with "/api" and use the authMiddleware.
+// Groups can be nested: v1 := api.Group("/v1") creates "/api/v1" prefix.
 func (s *Server) Group(prefix string, handlers ...Handler) *Group {
 	return &Group{
 		prefix:   prefix,

--- a/examples/groups/main.go
+++ b/examples/groups/main.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/rohanthewiz/rweb"
+)
+
+func main() {
+	// Create server
+	s := rweb.NewServer(rweb.ServerOptions{
+		Address: ":8080",
+		Verbose: true,
+	})
+
+	// Global middleware
+	s.Use(rweb.RequestInfo) // Logs all requests
+
+	// Public routes (no auth required)
+	s.Get("/", func(ctx rweb.Context) error {
+		return ctx.WriteHTML("<h1>Welcome to the API</h1><p>Visit /api/v1/status for API status</p>")
+	})
+
+	// API group with versioning
+	api := s.Group("/api")
+
+	// API v1
+	v1 := api.Group("/v1")
+	v1.Get("/status", func(ctx rweb.Context) error {
+		return ctx.WriteJSON(map[string]string{
+			"status":  "ok",
+			"version": "1.0",
+		})
+	})
+
+	// Users endpoints with authentication
+	users := v1.Group("/users", authMiddleware)
+	users.Get("/", listUsers)
+	users.Get("/:id", getUser)
+	users.Post("/", createUser)
+	users.Put("/:id", updateUser)
+	users.Delete("/:id", deleteUser)
+
+	// Admin routes with additional authorization
+	admin := s.Group("/admin", authMiddleware, adminMiddleware)
+	admin.Get("/dashboard", func(ctx rweb.Context) error {
+		return ctx.WriteHTML("<h1>Admin Dashboard</h1><p>Welcome, admin!</p>")
+	})
+	admin.Get("/users", func(ctx rweb.Context) error {
+		return ctx.WriteJSON(map[string]interface{}{
+			"users": []map[string]string{
+				{"id": "1", "name": "John", "role": "admin"},
+				{"id": "2", "name": "Jane", "role": "user"},
+			},
+		})
+	})
+	admin.Delete("/users/:id", func(ctx rweb.Context) error {
+		id := ctx.Request().Param("id")
+		return ctx.WriteJSON(map[string]string{
+			"message": fmt.Sprintf("User %s deleted by admin", id),
+		})
+	})
+
+	// Static files group
+	static := s.Group("/static")
+	static.Get("/version", func(ctx rweb.Context) error {
+		return ctx.WriteText("Static files version 1.0")
+	})
+	// In production, you might use:
+	// static.StaticFiles("/assets", "./public/assets", 0)
+
+	fmt.Println("Server starting on http://localhost:8080")
+	fmt.Println("Try these endpoints:")
+	fmt.Println("  GET  /")
+	fmt.Println("  GET  /api/v1/status")
+	fmt.Println("  GET  /api/v1/users (requires auth header)")
+	fmt.Println("  GET  /admin/dashboard (requires auth + admin)")
+
+	if err := s.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// Middleware functions
+func authMiddleware(ctx rweb.Context) error {
+	// Check for auth token
+	authHeader := ctx.Request().Header("Authorization")
+	if authHeader == "" {
+		return ctx.Status(401).WriteJSON(map[string]string{
+			"error": "Authentication required",
+		})
+	}
+
+	// In real app, validate the token
+	if authHeader != "Bearer valid-token" {
+		return ctx.Status(401).WriteJSON(map[string]string{
+			"error": "Invalid token",
+		})
+	}
+
+	// Store user info in context
+	ctx.Set("userId", "123")
+	ctx.Set("isAuthenticated", true)
+
+	return ctx.Next()
+}
+
+func adminMiddleware(ctx rweb.Context) error {
+	// Check if user is admin (in real app, check from DB or JWT claims)
+	// For demo, we'll check a specific header
+	if ctx.Request().Header("X-Admin") != "true" {
+		return ctx.Status(403).WriteJSON(map[string]string{
+			"error": "Admin access required",
+		})
+	}
+
+	ctx.Set("isAdmin", true)
+	return ctx.Next()
+}
+
+// Handler functions for users
+func listUsers(ctx rweb.Context) error {
+	return ctx.WriteJSON(map[string]interface{}{
+		"users": []map[string]string{
+			{"id": "1", "name": "John Doe"},
+			{"id": "2", "name": "Jane Smith"},
+		},
+	})
+}
+
+func getUser(ctx rweb.Context) error {
+	id := ctx.Request().Param("id")
+	return ctx.WriteJSON(map[string]string{
+		"id":    id,
+		"name":  "John Doe",
+		"email": "john@example.com",
+	})
+}
+
+func createUser(ctx rweb.Context) error {
+	// In real app, parse request body
+	return ctx.WriteJSON(map[string]string{
+		"id":      "3",
+		"message": "User created successfully",
+	})
+}
+
+func updateUser(ctx rweb.Context) error {
+	id := ctx.Request().Param("id")
+	return ctx.WriteJSON(map[string]string{
+		"id":      id,
+		"message": "User updated successfully",
+	})
+}
+
+func deleteUser(ctx rweb.Context) error {
+	id := ctx.Request().Param("id")
+	return ctx.WriteJSON(map[string]string{
+		"id":      id,
+		"message": "User deleted successfully",
+	})
+}

--- a/examples/groups/main.go
+++ b/examples/groups/main.go
@@ -1,3 +1,6 @@
+// Package main demonstrates how to use route groups in rweb for organizing
+// routes with common prefixes and middleware.
+// This example shows API versioning, authentication, and role-based access control.
 package main
 
 import (
@@ -8,25 +11,27 @@ import (
 )
 
 func main() {
-	// Create server
+	// Create server with verbose logging to see request handling
 	s := rweb.NewServer(rweb.ServerOptions{
 		Address: ":8080",
 		Verbose: true,
 	})
 
-	// Global middleware
+	// Global middleware - applies to all routes in the server
 	s.Use(rweb.RequestInfo) // Logs all requests
 
-	// Public routes (no auth required)
+	// Public routes - accessible without authentication
 	s.Get("/", func(ctx rweb.Context) error {
 		return ctx.WriteHTML("<h1>Welcome to the API</h1><p>Visit /api/v1/status for API status</p>")
 	})
 
-	// API group with versioning
+	// API group - all routes under this group will have /api prefix
 	api := s.Group("/api")
 
-	// API v1
+	// API v1 - nested group creates /api/v1 prefix
+	// This pattern allows easy API versioning
 	v1 := api.Group("/v1")
+	// Status endpoint: GET /api/v1/status
 	v1.Get("/status", func(ctx rweb.Context) error {
 		return ctx.WriteJSON(map[string]string{
 			"status":  "ok",
@@ -34,19 +39,23 @@ func main() {
 		})
 	})
 
-	// Users endpoints with authentication
+	// Users group - all routes require authentication via authMiddleware
+	// Creates routes like: GET /api/v1/users, GET /api/v1/users/:id, etc.
 	users := v1.Group("/users", authMiddleware)
-	users.Get("/", listUsers)
-	users.Get("/:id", getUser)
-	users.Post("/", createUser)
-	users.Put("/:id", updateUser)
-	users.Delete("/:id", deleteUser)
+	users.Get("/", listUsers)        // GET /api/v1/users
+	users.Get("/:id", getUser)      // GET /api/v1/users/:id
+	users.Post("/", createUser)      // POST /api/v1/users
+	users.Put("/:id", updateUser)   // PUT /api/v1/users/:id
+	users.Delete("/:id", deleteUser) // DELETE /api/v1/users/:id
 
-	// Admin routes with additional authorization
+	// Admin routes - require both authentication AND admin privileges
+	// Middleware executes in order: authMiddleware -> adminMiddleware -> handler
 	admin := s.Group("/admin", authMiddleware, adminMiddleware)
+	// Admin dashboard: GET /admin/dashboard
 	admin.Get("/dashboard", func(ctx rweb.Context) error {
 		return ctx.WriteHTML("<h1>Admin Dashboard</h1><p>Welcome, admin!</p>")
 	})
+	// Admin user list with role information: GET /admin/users
 	admin.Get("/users", func(ctx rweb.Context) error {
 		return ctx.WriteJSON(map[string]interface{}{
 			"users": []map[string]string{
@@ -55,6 +64,7 @@ func main() {
 			},
 		})
 	})
+	// Admin user deletion: DELETE /admin/users/:id
 	admin.Delete("/users/:id", func(ctx rweb.Context) error {
 		id := ctx.Request().Param("id")
 		return ctx.WriteJSON(map[string]string{
@@ -62,14 +72,15 @@ func main() {
 		})
 	})
 
-	// Static files group
+	// Static files group - demonstrates grouping non-API routes
 	static := s.Group("/static")
 	static.Get("/version", func(ctx rweb.Context) error {
 		return ctx.WriteText("Static files version 1.0")
 	})
-	// In production, you might use:
+	// In production, you might serve actual static files:
 	// static.StaticFiles("/assets", "./public/assets", 0)
 
+	// Print usage instructions
 	fmt.Println("Server starting on http://localhost:8080")
 	fmt.Println("Try these endpoints:")
 	fmt.Println("  GET  /")
@@ -82,9 +93,11 @@ func main() {
 	}
 }
 
-// Middleware functions
+// authMiddleware validates authentication tokens.
+// In a real application, this would validate JWT tokens or session cookies.
+// For this demo, it expects "Authorization: Bearer valid-token" header.
 func authMiddleware(ctx rweb.Context) error {
-	// Check for auth token
+	// Check for auth token in Authorization header
 	authHeader := ctx.Request().Header("Authorization")
 	if authHeader == "" {
 		return ctx.Status(401).WriteJSON(map[string]string{
@@ -92,20 +105,27 @@ func authMiddleware(ctx rweb.Context) error {
 		})
 	}
 
-	// In real app, validate the token
+	// Simple token validation for demo purposes
+	// Real implementation would decode/verify JWT or lookup session
 	if authHeader != "Bearer valid-token" {
 		return ctx.Status(401).WriteJSON(map[string]string{
 			"error": "Invalid token",
 		})
 	}
 
-	// Store user info in context
+	// Store user info in context for use by handlers
+	// This data is available to all subsequent middleware and handlers
 	ctx.Set("userId", "123")
 	ctx.Set("isAuthenticated", true)
 
+	// Continue to next middleware/handler
 	return ctx.Next()
 }
 
+// adminMiddleware checks if authenticated user has admin privileges.
+// This runs after authMiddleware, so we know the user is authenticated.
+// For demo purposes, it checks for "X-Admin: true" header.
+// Real implementation would check user roles from database or JWT claims.
 func adminMiddleware(ctx rweb.Context) error {
 	// Check if user is admin (in real app, check from DB or JWT claims)
 	// For demo, we'll check a specific header
@@ -115,11 +135,13 @@ func adminMiddleware(ctx rweb.Context) error {
 		})
 	}
 
+	// Mark user as admin in context
 	ctx.Set("isAdmin", true)
 	return ctx.Next()
 }
 
-// Handler functions for users
+// listUsers handles GET /api/v1/users
+// Returns a list of users (mock data for demo)
 func listUsers(ctx rweb.Context) error {
 	return ctx.WriteJSON(map[string]interface{}{
 		"users": []map[string]string{
@@ -129,7 +151,10 @@ func listUsers(ctx rweb.Context) error {
 	})
 }
 
+// getUser handles GET /api/v1/users/:id
+// Returns details for a specific user
 func getUser(ctx rweb.Context) error {
+	// Extract URL parameter
 	id := ctx.Request().Param("id")
 	return ctx.WriteJSON(map[string]string{
 		"id":    id,
@@ -138,24 +163,35 @@ func getUser(ctx rweb.Context) error {
 	})
 }
 
+// createUser handles POST /api/v1/users
+// Creates a new user (mock implementation)
 func createUser(ctx rweb.Context) error {
-	// In real app, parse request body
+	// In real app, you would:
+	// 1. Parse request body with ctx.Request().Body()
+	// 2. Validate the data
+	// 3. Save to database
 	return ctx.WriteJSON(map[string]string{
 		"id":      "3",
 		"message": "User created successfully",
 	})
 }
 
+// updateUser handles PUT /api/v1/users/:id
+// Updates an existing user
 func updateUser(ctx rweb.Context) error {
 	id := ctx.Request().Param("id")
+	// In real app: parse body, validate, update database
 	return ctx.WriteJSON(map[string]string{
 		"id":      id,
 		"message": "User updated successfully",
 	})
 }
 
+// deleteUser handles DELETE /api/v1/users/:id
+// Deletes a user (mock implementation)
 func deleteUser(ctx rweb.Context) error {
 	id := ctx.Request().Param("id")
+	// In real app: check permissions, delete from database
 	return ctx.WriteJSON(map[string]string{
 		"id":      id,
 		"message": "User deleted successfully",

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,295 @@
+package rweb_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rohanthewiz/assert"
+	"github.com/rohanthewiz/rweb"
+)
+
+func TestGroup(t *testing.T) {
+	s := rweb.NewServer()
+
+	// Test basic group
+	api := s.Group("/api")
+	api.Get("/users", func(ctx rweb.Context) error {
+		return ctx.WriteText("users list")
+	})
+	api.Post("/users", func(ctx rweb.Context) error {
+		return ctx.WriteText("user created")
+	})
+
+	// Test response
+	response := s.Request("GET", "/api/users", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "users list", string(response.Body()))
+
+	response = s.Request("POST", "/api/users", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "user created", string(response.Body()))
+
+	// Non-existent route
+	response = s.Request("GET", "/users", nil, nil)
+	assert.Equal(t, http.StatusNotFound, response.Status())
+}
+
+func TestGroupMiddleware(t *testing.T) {
+	s := rweb.NewServer()
+
+	// Track middleware execution
+	var executionOrder []string
+
+	// Server-level middleware
+	s.Use(func(ctx rweb.Context) error {
+		executionOrder = append(executionOrder, "server-middleware")
+		return ctx.Next()
+	})
+
+	// Group with middleware
+	api := s.Group("/api", func(ctx rweb.Context) error {
+		executionOrder = append(executionOrder, "api-middleware")
+		ctx.Response().SetHeader("X-API", "true")
+		return ctx.Next()
+	})
+
+	api.Get("/test", func(ctx rweb.Context) error {
+		executionOrder = append(executionOrder, "handler")
+		return ctx.WriteText("test response")
+	})
+
+	// Test request
+	executionOrder = []string{} // Reset
+	response := s.Request("GET", "/api/test", nil, nil)
+	
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "test response", string(response.Body()))
+	assert.Equal(t, "true", response.Header("X-API"))
+	assert.Equal(t, 3, len(executionOrder))
+	assert.Equal(t, "server-middleware", executionOrder[0])
+	assert.Equal(t, "api-middleware", executionOrder[1])
+	assert.Equal(t, "handler", executionOrder[2])
+}
+
+func TestNestedGroups(t *testing.T) {
+	s := rweb.NewServer()
+
+	// Create nested groups
+	api := s.Group("/api")
+	v1 := api.Group("/v1")
+	v2 := api.Group("/v2")
+
+	v1.Get("/status", func(ctx rweb.Context) error {
+		return ctx.WriteText("v1 status")
+	})
+
+	v2.Get("/status", func(ctx rweb.Context) error {
+		return ctx.WriteText("v2 status")
+	})
+
+	// Test both versions
+	response := s.Request("GET", "/api/v1/status", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "v1 status", string(response.Body()))
+
+	response = s.Request("GET", "/api/v2/status", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "v2 status", string(response.Body()))
+}
+
+func TestGroupAllMethods(t *testing.T) {
+	s := rweb.NewServer()
+	api := s.Group("/api")
+
+	// Register all HTTP methods
+	api.Get("/resource", func(ctx rweb.Context) error {
+		return ctx.WriteText("GET")
+	})
+	api.Post("/resource", func(ctx rweb.Context) error {
+		return ctx.WriteText("POST")
+	})
+	api.Put("/resource", func(ctx rweb.Context) error {
+		return ctx.WriteText("PUT")
+	})
+	api.Patch("/resource", func(ctx rweb.Context) error {
+		return ctx.WriteText("PATCH")
+	})
+	api.Delete("/resource", func(ctx rweb.Context) error {
+		return ctx.WriteText("DELETE")
+	})
+	api.Head("/resource", func(ctx rweb.Context) error {
+		ctx.Response().SetHeader("X-Method", "HEAD")
+		return nil
+	})
+	api.Options("/resource", func(ctx rweb.Context) error {
+		return ctx.WriteText("OPTIONS")
+	})
+
+	// Test each method
+	methods := []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
+	for _, method := range methods {
+		response := s.Request(method, "/api/resource", nil, nil)
+		assert.Equal(t, http.StatusOK, response.Status())
+		assert.Equal(t, method, string(response.Body()))
+	}
+
+	// Test HEAD
+	response := s.Request("HEAD", "/api/resource", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "HEAD", response.Header("X-Method"))
+}
+
+func TestGroupMiddlewareIndependence(t *testing.T) {
+	s := rweb.NewServer()
+
+	// Create two groups with different middleware
+	auth := s.Group("/auth", func(ctx rweb.Context) error {
+		ctx.Response().SetHeader("X-Auth", "required")
+		return ctx.Next()
+	})
+
+	public := s.Group("/public", func(ctx rweb.Context) error {
+		ctx.Response().SetHeader("X-Public", "true")
+		return ctx.Next()
+	})
+
+	auth.Get("/profile", func(ctx rweb.Context) error {
+		return ctx.WriteText("auth profile")
+	})
+
+	public.Get("/info", func(ctx rweb.Context) error {
+		return ctx.WriteText("public info")
+	})
+
+	// Test auth group
+	response := s.Request("GET", "/auth/profile", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "auth profile", string(response.Body()))
+	assert.Equal(t, "required", response.Header("X-Auth"))
+	assert.Equal(t, "", response.Header("X-Public")) // Should not have public header
+
+	// Test public group
+	response = s.Request("GET", "/public/info", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "public info", string(response.Body()))
+	assert.Equal(t, "true", response.Header("X-Public"))
+	assert.Equal(t, "", response.Header("X-Auth")) // Should not have auth header
+}
+
+func TestGroupUseMethod(t *testing.T) {
+	s := rweb.NewServer()
+
+	var middlewareOrder []string
+
+	api := s.Group("/api")
+	
+	// Add middleware after group creation
+	api.Use(func(ctx rweb.Context) error {
+		middlewareOrder = append(middlewareOrder, "first")
+		return ctx.Next()
+	})
+
+	api.Use(func(ctx rweb.Context) error {
+		middlewareOrder = append(middlewareOrder, "second")
+		return ctx.Next()
+	})
+
+	api.Get("/test", func(ctx rweb.Context) error {
+		middlewareOrder = append(middlewareOrder, "handler")
+		return ctx.WriteText("done")
+	})
+
+	// Test execution order
+	middlewareOrder = []string{}
+	response := s.Request("GET", "/api/test", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, 3, len(middlewareOrder))
+	assert.Equal(t, "first", middlewareOrder[0])
+	assert.Equal(t, "second", middlewareOrder[1])
+	assert.Equal(t, "handler", middlewareOrder[2])
+}
+
+func TestGroupErrorHandling(t *testing.T) {
+	s := rweb.NewServer()
+
+	api := s.Group("/api", func(ctx rweb.Context) error {
+		// Middleware that might error
+		if ctx.Request().Path() == "/api/error" {
+			return ctx.Error("middleware error")
+		}
+		return ctx.Next()
+	})
+
+	api.Get("/test", func(ctx rweb.Context) error {
+		return ctx.WriteText("success")
+	})
+
+	api.Get("/error", func(ctx rweb.Context) error {
+		return ctx.WriteText("should not reach here")
+	})
+
+	// Test successful request
+	response := s.Request("GET", "/api/test", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "success", string(response.Body()))
+
+	// Test error in middleware
+	response = s.Request("GET", "/api/error", nil, nil)
+	assert.Equal(t, http.StatusInternalServerError, response.Status())
+	// The default error handler should handle it
+	assert.True(t, strings.Contains(string(response.Body()), "Internal Server Error"))
+}
+
+func TestGroupStaticFiles(t *testing.T) {
+	s := rweb.NewServer()
+
+	// Create a group for assets
+	assets := s.Group("/assets")
+	
+	// This would serve files from the local "static" directory
+	// when requests come to /assets/static/*
+	// Note: We can't test this fully without actual files
+	assets.StaticFiles("/static", "./testdata", 0)
+
+	// Just verify the route is registered properly
+	// In a real test, you'd need actual static files to serve
+}
+
+func TestGroupProxy(t *testing.T) {
+	s := rweb.NewServer()
+
+	// Create API group
+	api := s.Group("/api")
+	
+	// Set up proxy (this would forward /api/external/* to another server)
+	// Note: We can't test this fully without a target server
+	err := api.Proxy("/external", "http://example.com", 0)
+	assert.Nil(t, err)
+}
+
+func TestGroupWithParameters(t *testing.T) {
+	s := rweb.NewServer()
+
+	users := s.Group("/users")
+	
+	users.Get("/:id", func(ctx rweb.Context) error {
+		id := ctx.Request().Param("id")
+		return ctx.WriteText("user " + id)
+	})
+
+	users.Get("/:id/posts/:postId", func(ctx rweb.Context) error {
+		userID := ctx.Request().Param("id")
+		postID := ctx.Request().Param("postId")
+		return ctx.WriteText("user " + userID + " post " + postID)
+	})
+
+	// Test parameter extraction
+	response := s.Request("GET", "/users/123", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "user 123", string(response.Body()))
+
+	response = s.Request("GET", "/users/123/posts/456", nil, nil)
+	assert.Equal(t, http.StatusOK, response.Status())
+	assert.Equal(t, "user 123 post 456", string(response.Body()))
+}


### PR DESCRIPTION
- Add Group struct for organizing routes with common prefixes
- Support group-specific middleware that only applies to routes in the group
- Enable nested groups for API versioning (e.g., /api/v1/users)
- Implement all HTTP methods on groups (Get, Post, Put, Patch, Delete, etc.)
- Add support for StaticFiles, Proxy, and SSEHandler on groups
- Include comprehensive tests for group functionality
- Add example demonstrating groups with authentication and admin routes
- Update README with route groups documentation

Route groups allow better organization of routes and middleware scoping, making it easier to build larger applications with proper separation of concerns.

🤖 Generated with [Claude Code](https://claude.ai/code)