### PR TITLE
Fix SVG MIME type to image/svg+xml

### DIFF
--- a/consts/mime.go
+++ b/consts/mime.go
@@ -13,7 +13,7 @@ const (
 	MIMEPNG               = "image/png"
 	MIMEJPEG              = "image/jpeg"
 	MIMEGIF               = "image/gif"
-	MIMESVG               = "image/svg"
+	MIMESVG               = "image/svg+xml"
 	MIMEZIP               = "application/zip"
 )
 

--- a/send_test.go
+++ b/send_test.go
@@ -147,7 +147,7 @@ func TestFileHeaders(t *testing.T) {
 		{
 			name:                 "SVG - viewable, with charset (XML-based)",
 			url:                  "/svg",
-			expectedContentType:  "image/svg; charset=utf-8",
+			expectedContentType:  "image/svg+xml; charset=utf-8",
 			shouldHaveDownload:   false,
 			shouldHaveCharset:    true,
 			expectedResponseBody: "<svg></svg>",
@@ -238,7 +238,7 @@ func TestFileMimeTypeExtensions(t *testing.T) {
 		{"file.jpg", "image/jpeg", false},
 		{"file.jpeg", "image/jpeg", false},
 		{"file.gif", "image/gif", false},
-		{"file.svg", "image/svg; charset=utf-8", false}, // SVG is text-based (XML)
+		{"file.svg", "image/svg+xml; charset=utf-8", false}, // SVG is text-based (XML)
 		{"file.ico", "image/x-icon", false},
 		{"file.webp", "image/webp", false},
 


### PR DESCRIPTION
## Summary
- `consts.MIMESVG` was set to `"image/svg"`, which is not a registered MIME type.
- Browsers receiving this header fail to render SVGs in `<img>` tags (broken/unknown image) and download the file on direct navigation instead of displaying it.
- Updated to the standards-compliant `"image/svg+xml"` (per RFC 3023 / IANA registry). Also updated the two `send_test.go` cases that pinned the old value.

## Test plan
- [x] `go test ./...` passes
- [ ] Manually verify a `.svg` served via `StaticFiles` renders inline in `<img>` tags and displays (not downloads) when navigated to directly