### PR TITLE
Add MIME types for wasm, mjs, avif, yaml, markdown, etc.

### DIFF
--- a/send.go
+++ b/send.go
@@ -48,14 +48,27 @@ func setFileHeaders(ctx Context, filename string, modTime time.Time) {
 	case ".css":
 		mimeType = "text/css"
 		isTextBased = true
-	case ".js":
+	case ".js", ".mjs":
+		// .mjs is the standard extension for ES modules; both share the JS MIME type per RFC 9239
 		mimeType = "text/javascript"
 		isTextBased = true
 	case ".json":
 		mimeType = consts.MIMEJSON
 		isTextBased = true
+	case ".map":
+		// Source maps are JSON; serving them with a JSON type lets DevTools fetch them cleanly
+		mimeType = consts.MIMEJSON
+		isTextBased = true
 	case ".xml":
 		mimeType = consts.MIMEXML
+		isTextBased = true
+	case ".yaml", ".yml":
+		// RFC 9512 (Feb 2024) registered application/yaml as the canonical type
+		mimeType = "application/yaml"
+		isTextBased = true
+	case ".md":
+		// RFC 7763
+		mimeType = "text/markdown"
 		isTextBased = true
 	case ".txt", ".log":
 		mimeType = consts.MIMETextPlain
@@ -78,6 +91,14 @@ func setFileHeaders(ctx Context, filename string, modTime time.Time) {
 		mimeType = "image/x-icon"
 	case ".webp":
 		mimeType = "image/webp"
+	case ".avif":
+		mimeType = "image/avif"
+	case ".bmp":
+		mimeType = "image/bmp"
+
+	// WebAssembly — browsers' streaming compile (instantiateStreaming) requires this exact type
+	case ".wasm":
+		mimeType = "application/wasm"
 
 	// Document formats (typically downloadable)
 	case ".pdf":
@@ -127,6 +148,10 @@ func setFileHeaders(ctx Context, filename string, modTime time.Time) {
 		mimeType = "audio/ogg"
 	case ".m4a":
 		mimeType = "audio/mp4"
+	case ".flac":
+		mimeType = "audio/flac"
+	case ".aac":
+		mimeType = "audio/aac"
 
 	// Video formats
 	case ".mp4":
@@ -241,8 +266,8 @@ func Text(ctx Context, body string) error {
 	return ctx.WriteString(body)
 }
 
-// XML sends the body with the content type set to `text/xml`.
+// XML sends the body with the content type set to `application/xml`.
 func XML(ctx Context, body string) error {
-	ctx.Response().SetHeader("Content-Type", "text/xml")
+	ctx.Response().SetHeader("Content-Type", consts.MIMEXML)
 	return ctx.WriteString(body)
 }

--- a/send_test.go
+++ b/send_test.go
@@ -54,7 +54,7 @@ func TestContentTypes(t *testing.T) {
 		{Method: consts.MethodGet, URL: "/js", Status: 200, Response: "console.log(42)", ContentType: "text/javascript"},
 		{Method: consts.MethodGet, URL: "/json", Status: 200, Response: "{\"Name\":\"User 1\"}\n", ContentType: "application/json"},
 		{Method: consts.MethodGet, URL: "/text", Status: 200, Response: "Hello", ContentType: "text/plain"},
-		{Method: consts.MethodGet, URL: "/xml", Status: 200, Response: "<xml></xml>", ContentType: "text/xml"},
+		{Method: consts.MethodGet, URL: "/xml", Status: 200, Response: "<xml></xml>", ContentType: "application/xml"},
 	}
 
 	for _, test := range tests {
@@ -227,8 +227,13 @@ func TestFileMimeTypeExtensions(t *testing.T) {
 		{"file.htm", "text/html; charset=utf-8", false},
 		{"file.css", "text/css; charset=utf-8", false},
 		{"file.js", "text/javascript; charset=utf-8", false},
+		{"file.mjs", "text/javascript; charset=utf-8", false},
 		{"file.json", "application/json; charset=utf-8", false},
+		{"file.map", "application/json; charset=utf-8", false},
 		{"file.xml", "application/xml; charset=utf-8", false},
+		{"file.yaml", "application/yaml; charset=utf-8", false},
+		{"file.yml", "application/yaml; charset=utf-8", false},
+		{"file.md", "text/markdown; charset=utf-8", false},
 		{"file.txt", "text/plain; charset=utf-8", false},
 		{"file.log", "text/plain; charset=utf-8", false},
 		{"file.csv", "text/csv; charset=utf-8", false},
@@ -241,6 +246,11 @@ func TestFileMimeTypeExtensions(t *testing.T) {
 		{"file.svg", "image/svg+xml; charset=utf-8", false}, // SVG is text-based (XML)
 		{"file.ico", "image/x-icon", false},
 		{"file.webp", "image/webp", false},
+		{"file.avif", "image/avif", false},
+		{"file.bmp", "image/bmp", false},
+
+		// WebAssembly (binary, viewable — must NOT be downloadable for streaming compile)
+		{"file.wasm", "application/wasm", false},
 
 		// Documents (binary formats, no charset)
 		{"file.pdf", "application/pdf", false},
@@ -264,6 +274,8 @@ func TestFileMimeTypeExtensions(t *testing.T) {
 		{"file.wav", "audio/wav", false},
 		{"file.ogg", "audio/ogg", false},
 		{"file.m4a", "audio/mp4", false},
+		{"file.flac", "audio/flac", false},
+		{"file.aac", "audio/aac", false},
 
 		// Video (binary formats, no charset)
 		{"file.mp4", "video/mp4", false},


### PR DESCRIPTION
## Summary
Adds MIME-type entries for several common modern extensions that previously fell through to `application/octet-stream` and were served with forced-download headers — breaking inline usage.

**New entries**
- `.wasm` → `application/wasm` *(browsers' streaming compile, `WebAssembly.instantiateStreaming`, requires this exact type)*
- `.mjs` → `text/javascript` *(ES modules; per RFC 9239)*
- `.map` → `application/json` *(source maps)*
- `.yaml` / `.yml` → `application/yaml` *(per RFC 9512)*
- `.md` → `text/markdown` *(per RFC 7763)*
- `.avif` → `image/avif`
- `.bmp` → `image/bmp`
- `.flac` → `audio/flac`
- `.aac` → `audio/aac`

**Cleanup**
- `XML()` helper now uses `consts.MIMEXML` (`application/xml`) instead of the hardcoded `"text/xml"`. Both are valid per RFC 7303 but `application/xml` is the preferred form, and the helper now matches the constant.

## Test plan
- [x] `go test ./...` passes
- [x] Added table-driven test cases for each new extension in `send_test.go`
- [x] Updated the `/xml` helper test to expect `application/xml`