### PR TITLE
Fix cross-request form state leaks; add multipart regression tests

### DIFF
--- a/Context.go
+++ b/Context.go
@@ -222,8 +222,21 @@ func (ctx *context) Clean() {
 	ctx.response.body = ctx.response.body[:0]
 	ctx.params = ctx.params[:0]
 
-	// Reset request state flags
+	// ContentType is a cached []byte shortcut populated when the
+	// "Content-Type" header is read. It must be cleared between requests
+	// because the next request on the same connection may not send a
+	// Content-Type header at all (e.g. a GET); without this reset, a
+	// prior POST's Content-Type leaks through and silently steers
+	// parsePostArgs / FormValue / ParseMultipartForm down the wrong path.
+	ctx.request.ContentType = nil
+
+	// Reset request state flags AND the parsed-args slice itself.
+	// Resetting only the flag is not enough: parsePostArgs early-returns
+	// when Content-Type isn't urlencoded, so the next request (e.g. a GET)
+	// would see the previous request's args via GetPostValue → PostArgs,
+	// which returns &req.postArgs unconditionally.
 	ctx.parsedPostArgs = false
+	ctx.request.postArgs.Reset()
 
 	// Reset middleware chain position
 	ctx.handlerIndex = 0

--- a/Context.go
+++ b/Context.go
@@ -1,10 +1,13 @@
 package rweb
 
 import (
+	"encoding/base64"
 	"errors"
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/rohanthewiz/rweb/consts"
 )
 
 // Context is the interface for a request and its response.
@@ -151,6 +154,27 @@ type Context interface {
 	// UserAgent returns the User-Agent header value from the request.
 	// Returns an empty string if the User-Agent header is not present.
 	UserAgent() string
+
+	// NoContent writes a 204 No Content response with no body.
+	// Common for successful DELETE / PATCH operations that have nothing
+	// meaningful to return. The Content-Type header is intentionally not
+	// set, since 204 responses MUST NOT carry a body per RFC 7230.
+	NoContent() error
+
+	// ClientIP returns the best-guess client IP for this request, applying
+	// the resolution order most production setups want behind a reverse
+	// proxy: X-Forwarded-For (first hop) → X-Real-IP → RemoteAddr.
+	// Returns an empty string only if all three are unavailable.
+	// SECURITY NOTE: X-Forwarded-For is trivially spoofable by clients
+	// when no proxy strips it. Treat the result as untrusted unless your
+	// edge proxy is configured to overwrite these headers.
+	ClientIP() string
+
+	// BasicAuth parses the Authorization header for HTTP Basic credentials
+	// per RFC 7617. Returns the decoded username and password and ok=true
+	// only when the header is present, well-formed, base64-decodes, and
+	// contains a `:` separator.
+	BasicAuth() (user, pass string, ok bool)
 }
 
 // context is the concrete implementation of the Context interface.
@@ -673,4 +697,67 @@ func (ctx *context) UserAgent() string {
 		}
 	}
 	return ""
+}
+
+// NoContent writes a 204 No Content response. Body is intentionally empty —
+// per RFC 7230 a 204 response MUST NOT include a message body.
+func (ctx *context) NoContent() error {
+	ctx.response.SetStatus(consts.StatusNoContent)
+	return nil
+}
+
+// ClientIP resolves the client IP using the order most reverse-proxied
+// deployments want:
+//  1. X-Forwarded-For — first comma-separated entry (the original client).
+//  2. X-Real-IP — single value set by some proxies (nginx default).
+//  3. The conn's RemoteAddr, with the port stripped.
+//
+// We deliberately do NOT trust XFF/X-Real-IP unconditionally — see the
+// security note on the interface declaration. The header lookup uses the
+// case-insensitive Header() helper.
+func (ctx *context) ClientIP() string {
+	if xff := ctx.request.Header("X-Forwarded-For"); xff != "" {
+		// XFF is "client, proxy1, proxy2"; the leftmost entry is the
+		// original client (assuming the chain is honest).
+		if comma := strings.IndexByte(xff, ','); comma >= 0 {
+			xff = xff[:comma]
+		}
+		if ip := strings.TrimSpace(xff); ip != "" {
+			return ip
+		}
+	}
+	if xri := strings.TrimSpace(ctx.request.Header("X-Real-IP")); xri != "" {
+		return xri
+	}
+	if ctx.conn != nil {
+		addr := ctx.conn.RemoteAddr().String()
+		// RemoteAddr is "host:port" (or "[v6]:port"); strip the port if we can.
+		if host, _, err := net.SplitHostPort(addr); err == nil {
+			return host
+		}
+		return addr
+	}
+	return ""
+}
+
+// BasicAuth parses an `Authorization: Basic <b64>` header per RFC 7617.
+// Returns ok=true only when the header is present, well-formed, decodes
+// cleanly as base64, and contains a `:` separator. Empty username or
+// empty password are still valid per the RFC.
+func (ctx *context) BasicAuth() (user, pass string, ok bool) {
+	const prefix = "Basic "
+	h := ctx.request.Header("Authorization")
+	if len(h) < len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return
+	}
+	raw, err := base64.StdEncoding.DecodeString(h[len(prefix):])
+	if err != nil {
+		return
+	}
+	s := string(raw)
+	i := strings.IndexByte(s, ':')
+	if i < 0 {
+		return
+	}
+	return s[:i], s[i+1:], true
 }

--- a/Context_test.go
+++ b/Context_test.go
@@ -1,7 +1,13 @@
 package rweb_test
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 
 	"github.com/rohanthewiz/assert"
@@ -69,4 +75,158 @@ func TestRedirect(t *testing.T) {
 	response := s.Request(consts.MethodGet, "/", nil, nil)
 	assert.Equal(t, response.Status(), 301)
 	assert.Equal(t, response.Header("Location"), "/target")
+}
+
+func TestNoContent(t *testing.T) {
+	s := rweb.NewServer()
+
+	s.Delete("/widgets/:id", func(ctx rweb.Context) error {
+		return ctx.NoContent()
+	})
+
+	response := s.Request(consts.MethodDelete, "/widgets/42", nil, nil)
+	assert.Equal(t, int(response.Status()), int(consts.StatusNoContent))
+	assert.Equal(t, len(response.Body()), 0)
+}
+
+// TestClientIP exercises the X-Forwarded-For → X-Real-IP → RemoteAddr fallback.
+// The synthetic Request() path doesn't have a real net.Conn, so the
+// final fallback returns "" — which is the correct documented behavior.
+func TestClientIP(t *testing.T) {
+	s := rweb.NewServer()
+
+	var got string
+	s.Get("/whoami", func(ctx rweb.Context) error {
+		got = ctx.ClientIP()
+		return ctx.WriteString(got)
+	})
+
+	cases := []struct {
+		name    string
+		headers []rweb.Header
+		want    string
+	}{
+		{
+			name: "XFF wins; first entry, trimmed",
+			headers: []rweb.Header{
+				{Key: "X-Forwarded-For", Value: "203.0.113.7, 10.0.0.1, 10.0.0.2"},
+				{Key: "X-Real-IP", Value: "10.0.0.99"},
+			},
+			want: "203.0.113.7",
+		},
+		{
+			name:    "X-Real-IP used when XFF absent",
+			headers: []rweb.Header{{Key: "X-Real-IP", Value: "198.51.100.5"}},
+			want:    "198.51.100.5",
+		},
+		{
+			name:    "empty XFF entry falls through to X-Real-IP",
+			headers: []rweb.Header{{Key: "X-Forwarded-For", Value: "  "}, {Key: "X-Real-IP", Value: "198.51.100.6"}},
+			want:    "198.51.100.6",
+		},
+		{
+			name:    "no headers and no conn → empty string (synthetic Request path)",
+			headers: nil,
+			want:    "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got = ""
+			_ = s.Request(consts.MethodGet, "/whoami", tc.headers, nil)
+			assert.Equal(t, got, tc.want)
+		})
+	}
+}
+
+// TestClientIPRemoteAddrFallback exercises the third resolution branch:
+// when neither X-Forwarded-For nor X-Real-IP is set, ClientIP must return
+// the connection's RemoteAddr with the port stripped. The synthetic
+// Request() path doesn't carry a real conn, so this needs a real server.
+func TestClientIPRemoteAddrFallback(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	var captured atomic.Value // string
+	s.Get("/whoami", func(ctx rweb.Context) error {
+		captured.Store(ctx.ClientIP())
+		return ctx.WriteString("ok")
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		<-readyChan
+
+		// No XFF/X-Real-IP — exercise the RemoteAddr fallback.
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%s/whoami", s.GetListenPort()))
+		assert.Nil(t, err)
+		_ = resp.Body.Close()
+
+		ip, _ := captured.Load().(string)
+		// Port should be stripped (net.SplitHostPort succeeds on real conns).
+		// We accept either the IPv4 loopback (127.0.0.1) or the IPv6 loopback
+		// (::1) depending on how the OS resolves it.
+		if ip != "127.0.0.1" && ip != "::1" {
+			t.Errorf("expected loopback IP without port, got %q", ip)
+		}
+		// Defense in depth: ensure no `:port` slipped through.
+		if strings.Contains(ip, ":") && !strings.Contains(ip, "::") {
+			t.Errorf("ClientIP returned host:port form, expected host only: %q", ip)
+		}
+	}()
+
+	_ = s.Run()
+	<-clientDone
+}
+
+func TestBasicAuth(t *testing.T) {
+	s := rweb.NewServer()
+
+	type result struct{ user, pass string; ok bool }
+	var got result
+	s.Get("/auth", func(ctx rweb.Context) error {
+		u, p, ok := ctx.BasicAuth()
+		got = result{u, p, ok}
+		return ctx.WriteString("done")
+	})
+
+	mk := func(v string) []rweb.Header {
+		return []rweb.Header{{Key: "Authorization", Value: v}}
+	}
+	enc := func(s string) string {
+		return base64.StdEncoding.EncodeToString([]byte(s))
+	}
+
+	cases := []struct {
+		name  string
+		hdrs  []rweb.Header
+		user  string
+		pass  string
+		ok    bool
+	}{
+		{"valid creds", mk("Basic " + enc("alice:s3cret")), "alice", "s3cret", true},
+		{"empty password is valid per RFC", mk("Basic " + enc("alice:")), "alice", "", true},
+		{"empty username is valid per RFC", mk("Basic " + enc(":s3cret")), "", "s3cret", true},
+		{"colon in password is preserved", mk("Basic " + enc("u:a:b:c")), "u", "a:b:c", true},
+		{"case-insensitive scheme prefix", mk("basic " + enc("u:p")), "u", "p", true},
+		{"missing header → not ok", nil, "", "", false},
+		{"non-Basic scheme → not ok", mk("Bearer abc.def"), "", "", false},
+		{"malformed base64 → not ok", mk("Basic !!!not-base64!!!"), "", "", false},
+		{"no colon after decode → not ok", mk("Basic " + enc("nocolon")), "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got = result{}
+			_ = s.Request(consts.MethodGet, "/auth", tc.hdrs, nil)
+			assert.Equal(t, got.user, tc.user)
+			assert.Equal(t, got.pass, tc.pass)
+			assert.Equal(t, got.ok, tc.ok)
+		})
+	}
 }

--- a/Request.go
+++ b/Request.go
@@ -33,10 +33,14 @@ type ItfRequest interface {
 	Param(string) string
 	// PathParam retrieves a Path parameter's value.
 	PathParam(string) string
-	// GetPostValue retrieves the value of POST param - cannot be used for non-multipart forms
-	// use FormValue for multipart form values.
+	// GetPostValue retrieves a value from an application/x-www-form-urlencoded
+	// POST body. It does NOT read multipart form fields — use FormValue for those.
 	GetPostValue(string) string
-	// FormValue retrieves multipart form parameter values
+	// FormValue returns the first value for the named field across both
+	// multipart/form-data and application/x-www-form-urlencoded request bodies.
+	// For multipart requests, this lazily triggers parsing if not already done;
+	// parse failures cause an empty string to be returned (use GetFormFile when
+	// you need the underlying error).
 	FormValue(string) string
 	// GetFormFile returns the first file for the provided form key
 	GetFormFile(string) (multipart.File, *multipart.FileHeader, error)
@@ -63,14 +67,27 @@ type request struct {
 	body        []byte
 	params      []rtr.Parameter
 
-	multipartForm         *multipart.Form
-	multipartFormBoundary string
+	// multipartForm holds the parsed form once parsing has succeeded.
+	// multipartParseErr caches a prior parse failure so callers (GetFormFile,
+	// GetFormFiles, FormValue) all surface the same error instead of getting
+	// a generic "no multipart form data" message after a real parse error.
+	// multipartMaxMem is the per-request memory cap passed to ReadForm; when
+	// zero, defaultMultipartMaxMemory is used. It is configured from
+	// ServerOptions.MultipartMaxMemory at context construction time.
+	multipartForm     *multipart.Form
+	multipartParseErr error
+	multipartMaxMem   int64
 
 	queryArgs Args
 
 	postArgs       Args
 	parsedPostArgs bool
 }
+
+// defaultMultipartMaxMemory is the in-memory cap used by ReadForm when the
+// server hasn't configured one. Anything beyond this cap spills to temp files
+// (which are cleaned up by CleanupMultipartForm). 32 MB matches net/http.
+const defaultMultipartMaxMemory int64 = 32 << 20
 
 // Header returns the header value for the given key.
 // Performs case-sensitive match first (priority), then falls back to lowercase match if not found.
@@ -181,32 +198,58 @@ func (req *request) parsePostArgs() {
 	req.parsedPostArgs = true
 }
 
+// ParseMultipartForm parses the request body as a multipart form.
+//
+// Idempotent: a successful parse caches the form, and a failed parse caches
+// the error. Subsequent calls return the cached result without re-reading
+// the body. This lets the server eagerly pre-parse while still letting
+// handlers re-call defensively (via GetFormFile etc.) and see the same error.
+//
+// Memory limit comes from req.multipartMaxMem (configured via
+// ServerOptions.MultipartMaxMemory); falls back to defaultMultipartMaxMemory
+// when zero. Bytes beyond the cap spill to temp files which CleanupMultipartForm
+// removes.
 func (req *request) ParseMultipartForm() error {
+	// Fast paths: already parsed, or already known to be unparseable.
 	if req.multipartForm != nil {
 		return nil
 	}
-
-	// Get the Content-Type header
-	contentType := req.ContentType
-	if !bytes.HasPrefix(contentType, consts.BytMultipartFormData) {
-		return fmt.Errorf("not a multipart form request")
+	if req.multipartParseErr != nil {
+		return req.multipartParseErr
 	}
 
-	// Extract boundary
+	// Validate Content-Type before touching the body.
+	contentType := req.ContentType
+	if !bytes.HasPrefix(contentType, consts.BytMultipartFormData) {
+		req.multipartParseErr = fmt.Errorf("not a multipart form request")
+		return req.multipartParseErr
+	}
+
+	// Extract boundary parameter
 	_, params, err := mime.ParseMediaType(b2s(contentType))
 	if err != nil {
+		req.multipartParseErr = err
 		return err
 	}
 
 	boundary, ok := params["boundary"]
 	if !ok {
-		return fmt.Errorf("no boundary found in multipart form data")
+		req.multipartParseErr = fmt.Errorf("no boundary found in multipart form data")
+		return req.multipartParseErr
 	}
 
-	// Create a new multipart reader
+	// Resolve the in-memory cap; 0 means "use default".
+	maxMem := req.multipartMaxMem
+	if maxMem <= 0 {
+		maxMem = defaultMultipartMaxMemory
+	}
+
+	// req.body is already buffered, so wrapping with bytes.NewReader is cheap
+	// and lets us re-read if needed (it isn't, currently — caching prevents that).
 	reader := multipart.NewReader(bytes.NewReader(req.body), boundary)
-	form, err := reader.ReadForm(32 << 20) // 32MB max memory
+	form, err := reader.ReadForm(maxMem)
 	if err != nil {
+		req.multipartParseErr = err
 		return err
 	}
 
@@ -214,11 +257,16 @@ func (req *request) ParseMultipartForm() error {
 	return nil
 }
 
-// GetFormFile returns the first file for the provided form key
+// GetFormFile returns the first file for the provided form key.
+//
+// ParseMultipartForm is idempotent — if the server already pre-parsed the
+// form during request handling, this is a near-free no-op. If the pre-parse
+// failed (or never ran), the cached error is returned here so the handler
+// can react to it instead of seeing a generic "no multipart form data".
 func (req *request) GetFormFile(key string) (multipart.File, *multipart.FileHeader, error) {
-	// if err := req.ParseMultipartForm(); err != nil {
-	// 	return nil, nil, err
-	// }
+	if err := req.ParseMultipartForm(); err != nil {
+		return nil, nil, err
+	}
 
 	if req.multipartForm == nil {
 		return nil, nil, fmt.Errorf("no multipart form data")
@@ -245,8 +293,15 @@ func (req *request) GetFormFile(key string) (multipart.File, *multipart.FileHead
 // Mirrors GetFormFile but lets callers handle multi-file uploads
 // (e.g. <input type="file" multiple>). Caller calls .Open() on each
 // header to read; matches the stdlib idiom in mime/multipart.
-// As with GetFormFile, the multipart form must already be parsed.
+//
+// As with GetFormFile, ParseMultipartForm is invoked defensively so a
+// missed/failed pre-parse surfaces here rather than masquerading as
+// "no multipart form data".
 func (req *request) GetFormFiles(key string) ([]*multipart.FileHeader, error) {
+	if err := req.ParseMultipartForm(); err != nil {
+		return nil, err
+	}
+
 	if req.multipartForm == nil {
 		return nil, fmt.Errorf("no multipart form data")
 	}
@@ -263,19 +318,42 @@ func (req *request) GetFormFiles(key string) ([]*multipart.FileHeader, error) {
 	return files, nil
 }
 
-// FormValue returns the first value for the named component of the form data
+// FormValue returns the first value for the named component of the form data.
+//
+// Dispatch is by Content-Type rather than by "is multipartForm non-nil",
+// because the latter was the source of a cross-request data leak: with
+// connection keep-alive the same context is reused, and prior to the fix
+// req.multipartForm survived across requests, causing a urlencoded POST on
+// the same connection to read string values from the previous multipart
+// request's form. Anchoring on the *current* request's Content-Type is the
+// correct discriminator.
 func (req *request) FormValue(key string) string {
-	if req.multipartForm != nil {
+	if bytes.HasPrefix(req.ContentType, consts.BytMultipartFormData) {
+		// Lazy-parse defense: ParseMultipartForm is idempotent, so a successful
+		// server-side pre-parse short-circuits immediately. Errors are swallowed
+		// here (the caller asked for a value, not an error); use GetFormFile
+		// when the underlying parse error matters.
+		if err := req.ParseMultipartForm(); err != nil || req.multipartForm == nil {
+			return ""
+		}
 		if values := req.multipartForm.Value[key]; len(values) > 0 {
 			return values[0]
 		}
+		return ""
 	}
 	return req.GetPostValue(key)
 }
 
-// CleanupMultipartForm removes any temporary files
+// CleanupMultipartForm releases any temp files AND nils out the cached form
+// and parse error. The latter is the load-bearing part: contexts are pooled
+// across requests on a keep-alive connection, and leaving multipartForm /
+// multipartParseErr populated would cause the next request on that connection
+// to read stale form values via FormValue (Form.Value is a plain map that
+// RemoveAll does not clear) or to inherit a stale parse failure.
 func (req *request) CleanupMultipartForm() {
 	if req.multipartForm != nil {
 		_ = req.multipartForm.RemoveAll()
+		req.multipartForm = nil
 	}
+	req.multipartParseErr = nil
 }

--- a/Request.go
+++ b/Request.go
@@ -40,6 +40,11 @@ type ItfRequest interface {
 	FormValue(string) string
 	// GetFormFile returns the first file for the provided form key
 	GetFormFile(string) (multipart.File, *multipart.FileHeader, error)
+	// GetFormFiles returns all FileHeaders for the given form key.
+	// Caller is responsible for calling .Open() on each header to read.
+	// Returns an error when no multipart form has been parsed or no
+	// files exist under the key.
+	GetFormFiles(string) ([]*multipart.FileHeader, error)
 	Body() []byte
 }
 
@@ -234,6 +239,28 @@ func (req *request) GetFormFile(key string) (multipart.File, *multipart.FileHead
 	}
 
 	return file, files[0], nil
+}
+
+// GetFormFiles returns all FileHeaders for the given form key.
+// Mirrors GetFormFile but lets callers handle multi-file uploads
+// (e.g. <input type="file" multiple>). Caller calls .Open() on each
+// header to read; matches the stdlib idiom in mime/multipart.
+// As with GetFormFile, the multipart form must already be parsed.
+func (req *request) GetFormFiles(key string) ([]*multipart.FileHeader, error) {
+	if req.multipartForm == nil {
+		return nil, fmt.Errorf("no multipart form data")
+	}
+
+	if req.multipartForm.File == nil {
+		return nil, fmt.Errorf("no files in form")
+	}
+
+	files := req.multipartForm.File[key]
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no file found for key: %s", key)
+	}
+
+	return files, nil
 }
 
 // FormValue returns the first value for the named component of the form data

--- a/Request_leak_test.go
+++ b/Request_leak_test.go
@@ -1,0 +1,516 @@
+// Regression tests for the form-handling fixes landed in Request.go,
+// Context.go, and Server.go.
+//
+// The bugs being guarded against were all rooted in the fact that contexts
+// are pooled per *connection* (see Server.handleConnection): two consecutive
+// requests on the same keep-alive connection share the same *context, so any
+// state on req.multipartForm / req.postArgs that survived Clean() would leak
+// into the next request. Each test below forces connection reuse via a
+// shared *http.Transport (or a raw net.Conn for the parse-error case) and
+// uses httptrace to *verify* reuse — without that verification, a test that
+// happened to land on a fresh connection would silently pass.
+package rweb_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/rohanthewiz/assert"
+	"github.com/rohanthewiz/rweb"
+)
+
+// keepAliveClient builds an http.Client whose underlying Transport will pool
+// idle connections so a follow-up request to the same host:port reuses the
+// previous connection. We pin MaxConnsPerHost=1 to make reuse the only option.
+func keepAliveClient() (*http.Client, *http.Transport) {
+	tr := &http.Transport{
+		MaxIdleConns:        1,
+		MaxIdleConnsPerHost: 1,
+		MaxConnsPerHost:     1,
+		IdleConnTimeout:     30 * time.Second,
+		DisableKeepAlives:   false,
+	}
+	return &http.Client{Transport: tr, Timeout: 5 * time.Second}, tr
+}
+
+// doWithReuseFlag executes req and records, via httptrace, whether the
+// dialer found an existing connection in the pool. The returned *bool is
+// non-nil and points to true iff this request reused a prior connection.
+func doWithReuseFlag(client *http.Client, req *http.Request) (*http.Response, *bool, error) {
+	reused := new(bool)
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			*reused = info.Reused
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+	resp, err := client.Do(req)
+	return resp, reused, err
+}
+
+// TestMultipartDoesNotLeakIntoFollowingGet guards FormValue's Content-Type
+// dispatch. Pre-fix, FormValue checked `req.multipartForm != nil` rather
+// than the current request's Content-Type — so a GET that landed on a
+// connection where the prior request was multipart could read string
+// values out of the previous request's *multipart.Form.
+func TestMultipartDoesNotLeakIntoFollowingGet(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	// Captures what the GET handler observed. A leaked value would land
+	// here as "request-one" instead of empty.
+	var getSawValue atomic.Pointer[string]
+
+	s.Post("/multipart", func(ctx rweb.Context) error {
+		// Sanity: confirm request 1 actually saw its own value, otherwise
+		// a regression that simply broke parsing would also pass the
+		// next assertion (vacuously).
+		if v := ctx.Request().FormValue("leaktest"); v != "request-one" {
+			return ctx.WriteString("first-mismatch:" + v)
+		}
+		return ctx.WriteString("ok-1")
+	})
+
+	s.Get("/check", func(ctx rweb.Context) error {
+		v := ctx.Request().FormValue("leaktest")
+		getSawValue.Store(&v)
+		return ctx.WriteString("ok-2")
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer func() { _ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM) }()
+		<-readyChan
+
+		client, tr := keepAliveClient()
+		defer tr.CloseIdleConnections()
+
+		// --- Request 1: multipart POST with the marker field. ---
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		_ = mw.WriteField("leaktest", "request-one")
+		assert.Nil(t, mw.Close())
+
+		url1 := fmt.Sprintf("http://127.0.0.1:%s/multipart", s.GetListenPort())
+		req1, _ := http.NewRequest(http.MethodPost, url1, &buf)
+		req1.Header.Set("Content-Type", mw.FormDataContentType())
+		resp1, _, err := doWithReuseFlag(client, req1)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp1.Body) // drain so conn returns to pool
+		_ = resp1.Body.Close()
+
+		// --- Request 2: plain GET on the same connection. ---
+		url2 := fmt.Sprintf("http://127.0.0.1:%s/check", s.GetListenPort())
+		req2, _ := http.NewRequest(http.MethodGet, url2, nil)
+		resp2, reused, err := doWithReuseFlag(client, req2)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp2.Body)
+		_ = resp2.Body.Close()
+
+		// Without connection reuse the test would not exercise the bug.
+		assert.Equal(t, *reused, true)
+
+		got := getSawValue.Load()
+		if got == nil {
+			t.Errorf("GET handler did not run")
+			return
+		}
+		if *got != "" {
+			t.Errorf("multipart→GET leak: FormValue('leaktest') on GET = %q (want empty)", *got)
+		}
+	}()
+
+	_ = s.Run()
+	<-clientDone
+}
+
+// TestMultipartDoesNotLeakIntoFollowingMultipart guards CleanupMultipartForm.
+// The first request submits `leaktest`; the second submits a different field
+// only. Pre-fix, multipartForm survived Cleanup (RemoveAll() doesn't clear
+// Form.Value), and ParseMultipartForm short-circuited on the still-non-nil
+// pointer — so request 2 saw request 1's values. The fix nils out
+// multipartForm in CleanupMultipartForm.
+func TestMultipartDoesNotLeakIntoFollowingMultipart(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	var (
+		req1Saw atomic.Pointer[string]
+		req2Saw atomic.Pointer[string]
+	)
+
+	s.Post("/upload", func(ctx rweb.Context) error {
+		v := ctx.Request().FormValue("leaktest")
+		// Distinguish the two requests by a header the client sets.
+		switch ctx.Request().Header("X-Phase") {
+		case "1":
+			req1Saw.Store(&v)
+		case "2":
+			req2Saw.Store(&v)
+		}
+		return ctx.WriteString("ok")
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer func() { _ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM) }()
+		<-readyChan
+
+		client, tr := keepAliveClient()
+		defer tr.CloseIdleConnections()
+		urlBase := fmt.Sprintf("http://127.0.0.1:%s/upload", s.GetListenPort())
+
+		// --- Request 1: multipart with leaktest=request-one. ---
+		var buf1 bytes.Buffer
+		mw1 := multipart.NewWriter(&buf1)
+		_ = mw1.WriteField("leaktest", "request-one")
+		assert.Nil(t, mw1.Close())
+
+		req1, _ := http.NewRequest(http.MethodPost, urlBase, &buf1)
+		req1.Header.Set("Content-Type", mw1.FormDataContentType())
+		req1.Header.Set("X-Phase", "1")
+		resp1, _, err := doWithReuseFlag(client, req1)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp1.Body)
+		_ = resp1.Body.Close()
+
+		// --- Request 2: multipart that does NOT include `leaktest`. ---
+		var buf2 bytes.Buffer
+		mw2 := multipart.NewWriter(&buf2)
+		_ = mw2.WriteField("other", "request-two")
+		assert.Nil(t, mw2.Close())
+
+		req2, _ := http.NewRequest(http.MethodPost, urlBase, &buf2)
+		req2.Header.Set("Content-Type", mw2.FormDataContentType())
+		req2.Header.Set("X-Phase", "2")
+		resp2, reused, err := doWithReuseFlag(client, req2)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp2.Body)
+		_ = resp2.Body.Close()
+
+		assert.Equal(t, *reused, true)
+
+		// Sanity: request 1 must have seen its own value (otherwise a
+		// regression that broke parsing entirely would also pass the
+		// next assertion vacuously).
+		v1 := req1Saw.Load()
+		if v1 == nil || *v1 != "request-one" {
+			s := ""
+			if v1 != nil {
+				s = *v1
+			}
+			t.Errorf("request 1 sanity failed: FormValue('leaktest') = %q", s)
+			return
+		}
+
+		v2 := req2Saw.Load()
+		if v2 == nil {
+			t.Errorf("request 2 handler did not run")
+			return
+		}
+		if *v2 != "" {
+			t.Errorf("multipart→multipart leak: FormValue('leaktest') on request 2 = %q (want empty)", *v2)
+		}
+	}()
+
+	_ = s.Run()
+	<-clientDone
+}
+
+// TestPostArgsDoNotLeakIntoFollowingNonFormPost guards Context.Clean's
+// postArgs reset.
+//
+// Subtle but important: this test deliberately sends `Content-Type:
+// application/json` on request 2 — *not* a GET. Reason: parsePostArgs
+// returns early when Content-Type doesn't match BytFormData, and on a GET
+// (no Content-Type header) the now-cleared `req.ContentType` cache routes
+// through that early-return path BUT also resets postArgs as a side-effect
+// of the ParseBytes(empty) call when ContentType happens to be carried over
+// (the original ContentType-leak bug). To pin down the postArgs reset fix
+// without those interactions, we send a request that is unambiguously
+// non-form: parsePostArgs early-returns, and the only thing standing
+// between the handler and the prior request's data is the explicit
+// postArgs.Reset() in Clean().
+func TestPostArgsDoNotLeakIntoFollowingNonFormPost(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	var checkSawValue atomic.Pointer[string]
+
+	s.Post("/post", func(ctx rweb.Context) error {
+		// Sanity that request 1 sees its own value.
+		if v := ctx.Request().GetPostValue("leaktest"); v != "request-one" {
+			return ctx.WriteString("first-mismatch:" + v)
+		}
+		return ctx.WriteString("ok-1")
+	})
+
+	s.Post("/check", func(ctx rweb.Context) error {
+		v := ctx.Request().GetPostValue("leaktest")
+		checkSawValue.Store(&v)
+		return ctx.WriteString("ok-2")
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer func() { _ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM) }()
+		<-readyChan
+
+		client, tr := keepAliveClient()
+		defer tr.CloseIdleConnections()
+
+		// --- Request 1: urlencoded POST. ---
+		body := strings.NewReader("leaktest=request-one&other=foo")
+		req1, _ := http.NewRequest(http.MethodPost,
+			fmt.Sprintf("http://127.0.0.1:%s/post", s.GetListenPort()), body)
+		req1.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp1, _, err := doWithReuseFlag(client, req1)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp1.Body)
+		_ = resp1.Body.Close()
+
+		// --- Request 2: JSON POST on the same connection. ---
+		// Content-Type is application/json, NOT application/x-www-form-urlencoded.
+		// This forces parsePostArgs to early-return on Content-Type mismatch,
+		// so the only thing keeping postArgs from leaking is the explicit
+		// Reset() we added in Clean().
+		jsonBody := strings.NewReader(`{"hello":"world"}`)
+		req2, _ := http.NewRequest(http.MethodPost,
+			fmt.Sprintf("http://127.0.0.1:%s/check", s.GetListenPort()), jsonBody)
+		req2.Header.Set("Content-Type", "application/json")
+		resp2, reused, err := doWithReuseFlag(client, req2)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp2.Body)
+		_ = resp2.Body.Close()
+
+		assert.Equal(t, *reused, true)
+
+		got := checkSawValue.Load()
+		if got == nil {
+			t.Errorf("check handler did not run")
+			return
+		}
+		if *got != "" {
+			t.Errorf("urlencoded→JSON leak: GetPostValue('leaktest') on JSON POST = %q (want empty)", *got)
+		}
+	}()
+
+	_ = s.Run()
+	<-clientDone
+}
+
+// TestMalformedMultipartSurfacesParseError guards the error-caching path:
+// when ParseMultipartForm fails (here, because the Content-Type lacks a
+// boundary parameter), the cached error must reach the handler via
+// GetFormFile rather than being swallowed by the server-side eager parse
+// and replaced with the generic "no multipart form data" message.
+//
+// Uses a raw net.Conn because net/http would auto-add a boundary; we need
+// to hand-craft a malformed Content-Type.
+func TestMalformedMultipartSurfacesParseError(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	var sawErr atomic.Pointer[string]
+
+	s.Post("/upload", func(ctx rweb.Context) error {
+		_, _, err := ctx.Request().GetFormFile("anything")
+		if err != nil {
+			msg := err.Error()
+			sawErr.Store(&msg)
+		}
+		return ctx.WriteString("done")
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer func() { _ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM) }()
+		<-readyChan
+
+		// Hand-crafted HTTP/1.0 request: Content-Type declares multipart
+		// but provides no boundary parameter. ParseMultipartForm must
+		// fail and the error must propagate to GetFormFile.
+		conn, err := net.Dial("tcp", "127.0.0.1:"+s.GetListenPort())
+		assert.Nil(t, err)
+		defer func() { _ = conn.Close() }()
+
+		body := "garbage-no-multipart-structure"
+		raw := "POST /upload HTTP/1.0\r\n" +
+			"Host: 127.0.0.1\r\n" +
+			"Content-Type: multipart/form-data\r\n" + // missing boundary=...
+			fmt.Sprintf("Content-Length: %d\r\n", len(body)) +
+			"\r\n" +
+			body
+		_, err = conn.Write([]byte(raw))
+		assert.Nil(t, err)
+
+		// Drain response so the server completes the handler.
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, _ = io.ReadAll(conn)
+
+		got := sawErr.Load()
+		if got == nil {
+			t.Errorf("handler did not observe an error from GetFormFile")
+			return
+		}
+		// The fix routes the underlying parse error ("no boundary found
+		// in multipart form data") through GetFormFile. Pre-fix, the
+		// commented-out ParseMultipartForm call meant the handler only
+		// ever saw the generic "no multipart form data" sentinel.
+		if *got == "no multipart form data" {
+			t.Errorf("GetFormFile masked the real parse error with the generic sentinel: %q", *got)
+		}
+		if !strings.Contains(*got, "boundary") {
+			t.Errorf("expected error to mention boundary; got %q", *got)
+		}
+	}()
+
+	_ = s.Run()
+	<-clientDone
+}
+
+// TestContentTypeDoesNotLeakAcrossRequests guards Context.Clean's reset of
+// the cached `req.ContentType` byte slice.
+//
+// Pre-fix, ContentType was populated only when a "Content-Type" header was
+// observed during request parsing. A follow-up request that sent NO
+// Content-Type header inherited the previous request's value via the
+// uncleared cache. The visible symptom was that internal dispatch
+// (parsePostArgs / FormValue / ParseMultipartForm) routed against the
+// wrong content type. This test asserts the observable behavior: a GET
+// following a multipart POST must not have FormValue treat it as multipart.
+//
+// We probe via a fingerprint that's only reachable when ParseMultipartForm
+// runs against the leaked ContentType: with the fix, FormValue's
+// Content-Type check fails and the function falls through to GetPostValue
+// (which also returns ""), giving an empty result. Without the fix,
+// FormValue tries to parse, and the multipartParseErr would be cached —
+// detectable via GetFormFile returning that error.
+func TestContentTypeDoesNotLeakAcrossRequests(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	var (
+		req1Sanity     atomic.Pointer[string]
+		req2FormFileEr atomic.Pointer[string]
+	)
+
+	s.Post("/multipart", func(ctx rweb.Context) error {
+		v := ctx.Request().FormValue("marker")
+		req1Sanity.Store(&v)
+		return ctx.WriteString("ok-1")
+	})
+
+	s.Get("/probe", func(ctx rweb.Context) error {
+		// On a fresh GET (no Content-Type), GetFormFile must return the
+		// "no multipart form data" sentinel — not a parse error from
+		// trying to re-parse against a leaked multipart Content-Type.
+		_, _, err := ctx.Request().GetFormFile("anything")
+		if err != nil {
+			msg := err.Error()
+			req2FormFileEr.Store(&msg)
+		}
+		return ctx.WriteString("ok-2")
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer func() { _ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM) }()
+		<-readyChan
+
+		client, tr := keepAliveClient()
+		defer tr.CloseIdleConnections()
+
+		// --- Request 1: multipart with a recognizable boundary. ---
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		_ = mw.WriteField("marker", "value-one")
+		assert.Nil(t, mw.Close())
+
+		req1, _ := http.NewRequest(http.MethodPost,
+			fmt.Sprintf("http://127.0.0.1:%s/multipart", s.GetListenPort()), &buf)
+		req1.Header.Set("Content-Type", mw.FormDataContentType())
+		resp1, _, err := doWithReuseFlag(client, req1)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp1.Body)
+		_ = resp1.Body.Close()
+
+		// --- Request 2: GET, no Content-Type, on the same connection. ---
+		req2, _ := http.NewRequest(http.MethodGet,
+			fmt.Sprintf("http://127.0.0.1:%s/probe", s.GetListenPort()), nil)
+		resp2, reused, err := doWithReuseFlag(client, req2)
+		assert.Nil(t, err)
+		_, _ = io.Copy(io.Discard, resp2.Body)
+		_ = resp2.Body.Close()
+		assert.Equal(t, *reused, true)
+
+		// Sanity for request 1.
+		if s := req1Sanity.Load(); s == nil || *s != "value-one" {
+			got := ""
+			if s != nil {
+				got = *s
+			}
+			t.Errorf("request 1 sanity: FormValue('marker') = %q (want 'value-one')", got)
+			return
+		}
+
+		// On the GET, the handler must observe the generic
+		// "no multipart form data" sentinel — meaning the ContentType
+		// was correctly nil-reset and ParseMultipartForm short-circuited
+		// at the Content-Type prefix check. Pre-fix, the leaked
+		// "multipart/form-data; boundary=..." Content-Type would push
+		// through to ReadForm, producing a parse-time error here.
+		got := req2FormFileEr.Load()
+		if got == nil {
+			t.Errorf("GET handler did not capture an error from GetFormFile")
+			return
+		}
+		if *got != "no multipart form data" && *got != "not a multipart form request" {
+			t.Errorf("ContentType leaked: GetFormFile saw %q (expected 'no multipart form data' or 'not a multipart form request')", *got)
+		}
+	}()
+
+	_ = s.Run()
+	<-clientDone
+}
+
+// Compile-time guard that we still import context (used implicitly by
+// httptrace.WithClientTrace via req.Context()). Remove if unused warnings
+// appear during refactor.
+var _ = context.Background

--- a/Request_test.go
+++ b/Request_test.go
@@ -1,7 +1,14 @@
 package rweb_test
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 
 	"github.com/rohanthewiz/assert"
@@ -82,6 +89,148 @@ func TestRequestParam(t *testing.T) {
 	response := s.Request(consts.MethodGet, "/blog/my-article", nil, nil)
 	assert.Equal(t, response.Status(), 200)
 	assert.Equal(t, string(response.Body()), "my-article")
+}
+
+// TestGetFormFiles exercises the new multi-file accessor end-to-end. The
+// synthetic s.Request() path doesn't pipe the body through to the multipart
+// parser, so we use a real HTTP server here. Three files are uploaded under
+// the same form key to confirm we see all of them (not just the first, which
+// is what GetFormFile returns) and that filenames + contents survive intact.
+func TestGetFormFiles(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	type result struct {
+		count    int
+		names    []string
+		contents []string
+		err      string
+	}
+	var got atomic.Pointer[result]
+
+	s.Post("/upload", func(ctx rweb.Context) error {
+		files, err := ctx.Request().GetFormFiles("attachments")
+		r := result{}
+		if err != nil {
+			r.err = err.Error()
+		}
+		for _, fh := range files {
+			r.count++
+			r.names = append(r.names, fh.Filename)
+			f, oerr := fh.Open()
+			if oerr != nil {
+				r.err = oerr.Error()
+				continue
+			}
+			body, _ := io.ReadAll(f)
+			_ = f.Close()
+			r.contents = append(r.contents, string(body))
+		}
+		got.Store(&r)
+		return ctx.NoContent()
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		<-readyChan
+
+		// Build a real multipart body: two attachments under the same key,
+		// plus a normal text field, plus an unrelated file under a different
+		// key (which GetFormFiles("attachments") must NOT return).
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		_ = mw.WriteField("vehicle", "car")
+
+		w1, err := mw.CreateFormFile("attachments", "first.txt")
+		assert.Nil(t, err)
+		_, _ = w1.Write([]byte("alpha"))
+
+		w2, err := mw.CreateFormFile("attachments", "second.txt")
+		assert.Nil(t, err)
+		_, _ = w2.Write([]byte("beta"))
+
+		w3, err := mw.CreateFormFile("attachments", "third.txt")
+		assert.Nil(t, err)
+		_, _ = w3.Write([]byte("gamma"))
+
+		// Sanity decoy under a different key
+		wOther, err := mw.CreateFormFile("avatar", "ignored.png")
+		assert.Nil(t, err)
+		_, _ = wOther.Write([]byte("decoy"))
+
+		assert.Nil(t, mw.Close())
+
+		url := fmt.Sprintf("http://127.0.0.1:%s/upload", s.GetListenPort())
+		resp, err := http.Post(url, mw.FormDataContentType(), &buf)
+		assert.Nil(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, int(resp.StatusCode), int(consts.StatusNoContent))
+
+		r := got.Load()
+		if r == nil {
+			t.Error("handler did not capture any result")
+			return
+		}
+		if r.err != "" {
+			t.Errorf("handler reported error: %s", r.err)
+			return
+		}
+		assert.Equal(t, r.count, 3)
+		assert.Equal(t, strings.Join(r.names, ","), "first.txt,second.txt,third.txt")
+		assert.Equal(t, strings.Join(r.contents, ","), "alpha,beta,gamma")
+	}()
+
+	_ = s.Run()
+	<-clientDone
+}
+
+// TestGetFormFilesNotPresent confirms the error paths: the missing-key case
+// returns an error rather than silently returning nil/empty.
+func TestGetFormFilesNotPresent(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	clientDone := make(chan struct{})
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	var sawErr atomic.Bool
+	s.Post("/upload", func(ctx rweb.Context) error {
+		files, err := ctx.Request().GetFormFiles("nope")
+		if err != nil && len(files) == 0 {
+			sawErr.Store(true)
+		}
+		return ctx.NoContent()
+	})
+
+	go func() {
+		defer close(clientDone)
+		defer syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		<-readyChan
+
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		w, err := mw.CreateFormFile("attachments", "ok.txt")
+		assert.Nil(t, err)
+		_, _ = w.Write([]byte("hello"))
+		assert.Nil(t, mw.Close())
+
+		url := fmt.Sprintf("http://127.0.0.1:%s/upload", s.GetListenPort())
+		resp, err := http.Post(url, mw.FormDataContentType(), &buf)
+		assert.Nil(t, err)
+		_ = resp.Body.Close()
+		assert.Equal(t, sawErr.Load(), true)
+	}()
+
+	_ = s.Run()
+	<-clientDone
 }
 
 func TestUserAgent(t *testing.T) {

--- a/Server.go
+++ b/Server.go
@@ -14,10 +14,12 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/rohanthewiz/element"
 	"github.com/rohanthewiz/rweb/consts"
@@ -550,18 +552,49 @@ func (s *Server) StaticFiles(reqDir string, targetDir string, nbrOfTokensToStrip
 
 		// Build the actual filepath now
 		wildcardPath := ctx.Request().Param("path")
+
+		// Defensive: percent-decode and reject any traversal-bearing input before
+		// touching the filesystem. `filepath.Join` *normalizes* `..` segments
+		// rather than rejecting them, so a request like /static/../../etc/passwd
+		// would otherwise resolve outside `targetDir`. We refuse such requests
+		// with 404 (rather than 403) so we don't leak whether off-root targets exist.
+		decoded, decErr := url.PathUnescape(wildcardPath)
+		if decErr != nil || strings.ContainsRune(decoded, 0) ||
+			slices.Contains(strings.Split(decoded, "/"), "..") {
+			ctx.SetStatus(consts.StatusNotFound)
+			return nil
+		}
+
 		fileSpec := filepath.Join("/", targetDir,
-			strings.Join(rhTokens, "/"), wildcardPath)
+			strings.Join(rhTokens, "/"), decoded)
 		if s.options.Debug {
 			fmt.Println("**-> fileFullPath", fileSpec)
 		}
 
-		body, err := os.ReadFile("." + fileSpec)
+		// Belt-and-suspenders containment check: even with `..` rejected above,
+		// resolve both the configured root and the candidate to absolute paths
+		// and require the candidate to be inside the root via `filepath.Rel`.
+		// This catches any unforeseen normalization quirks (e.g. odd separators
+		// on different OSes) without re-implementing them ourselves.
+		rootAbs, rErr := filepath.Abs("." + filepath.Join("/", targetDir))
+		candAbs, cErr := filepath.Abs("." + fileSpec)
+		if rErr != nil || cErr != nil {
+			ctx.SetStatus(consts.StatusNotFound)
+			return nil
+		}
+		rel, relErr := filepath.Rel(rootAbs, candAbs)
+		if relErr != nil || rel == ".." ||
+			strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			ctx.SetStatus(consts.StatusNotFound)
+			return nil
+		}
+
+		body, err := os.ReadFile(candAbs)
 		if err != nil {
 			return err
 		}
 
-		return File(ctx, filepath.Base(fileSpec), body)
+		return File(ctx, filepath.Base(candAbs), body)
 	})
 }
 
@@ -1012,11 +1045,36 @@ func (s *Server) sendSSE(ctx *context, respWriter io.Writer) (err error) {
 	// A read on a half-closed or fully-closed TCP connection returns immediately
 	// (EOF or error), giving us sub-second disconnect detection instead of waiting
 	// up to a full heartbeat interval (~25s) to discover a broken pipe on write.
+	//
+	// The Read in the goroutine below otherwise blocks until the *client* closes,
+	// so on every other exit path (channel-close, "close" sentinel, write error)
+	// the goroutine would leak — parked on a conn the framework has stopped tracking.
+	// The defer below forces the parked Read to unblock by setting an immediate
+	// read deadline, then waits for the goroutine to finish before returning.
+	// The Read in the goroutine below otherwise blocks until the *client* closes,
+	// so on every other exit path (channel-close, "close" sentinel, write error)
+	// the goroutine would leak — parked on a conn the framework has stopped tracking.
+	// The defer below forces the parked Read to unblock by setting an immediate
+	// read deadline, then waits for the goroutine to finish before returning.
 	connGone := make(chan struct{})
+	var readerWG sync.WaitGroup
+	defer func() {
+		if ctx.conn != nil {
+			// Past-instant deadline: a Read already in-flight returns at once
+			// with a deadline-exceeded error. Side effect: the conn becomes
+			// unusable for further reads, which is fine — SSE streaming has
+			// finished and the conn isn't reused for keep-alive after this.
+			_ = ctx.conn.SetReadDeadline(time.Unix(1, 0))
+		}
+		readerWG.Wait()
+	}()
 	if ctx.conn != nil {
+		readerWG.Add(1)
 		go func() {
+			defer readerWG.Done()
 			buf := make([]byte, 1)
-			// Read blocks until the client closes or the conn is closed.
+			// Read blocks until the client closes, the conn is closed,
+			// or the deferred SetReadDeadline above fires.
 			// We don't expect any incoming data on an SSE connection.
 			_, _ = ctx.conn.Read(buf)
 			close(connGone)

--- a/Server.go
+++ b/Server.go
@@ -42,6 +42,14 @@ type ServerOptions struct {
 	// Cookie holds server-wide default settings for cookies
 	Cookie CookieConfig
 	SSECfg SSECfg
+
+	// MultipartMaxMemory is the in-memory cap (in bytes) used when parsing
+	// multipart/form-data bodies. Form parts beyond this cap spill to temp
+	// files (which Cleanup removes after each request). When zero, the
+	// framework default (32 MB, matching net/http) is used. Set this lower
+	// for endpoints that do not expect uploads, or higher for upload-heavy
+	// services where temp-file spillover is undesirable.
+	MultipartMaxMemory int64
 }
 
 type SSECfg struct {
@@ -145,6 +153,18 @@ func WithSSESendConnectedEvent() ServerOption {
 	}
 }
 
+// WithMultipartMaxMemory sets the in-memory cap (in bytes) used when parsing
+// multipart/form-data bodies. A value of 0 (or negative) selects the default
+// of 32 MB. Bytes beyond the cap spill to temporary files which the framework
+// cleans up automatically at the end of each request.
+//
+// Example: WithMultipartMaxMemory(8 << 20) // 8 MB cap
+func WithMultipartMaxMemory(n int64) ServerOption {
+	return func(opts *ServerOptions) {
+		opts.MultipartMaxMemory = n
+	}
+}
+
 // WithOptions creates a ServerOption from a ServerOptions struct.
 // This is provided for backwards compatibility with the old configuration style.
 // Example: WithOptions(ServerOptions{Address: ":8080", Verbose: true})
@@ -160,6 +180,7 @@ func WithOptions(serverOpts ServerOptions) ServerOption {
 		opts.ReadyChan = serverOpts.ReadyChan
 		opts.Cookie = serverOpts.Cookie
 		opts.SSECfg = serverOpts.SSECfg
+		opts.MultipartMaxMemory = serverOpts.MultipartMaxMemory
 	}
 }
 
@@ -1171,14 +1192,20 @@ func (s *Server) sendSSE(ctx *context, respWriter io.Writer) (err error) {
 }
 
 // newContext allocates a new context with the default state.
+//
+// multipartMaxMem is seeded from server options here (rather than per-request)
+// because (a) it's a stable server-wide setting, and (b) seeding it once at
+// pool creation avoids touching every request's hot path. Cleanup never
+// resets this field — it's config, not request state.
 func (s *Server) newContext() *context {
 	return &context{
 		server: s,
 		request: request{
-			reader:  bufio.NewReader(nil),
-			body:    make([]byte, 0),
-			headers: make([]Header, 0, 8),
-			params:  make([]rtr.Parameter, 0, 8),
+			reader:          bufio.NewReader(nil),
+			body:            make([]byte, 0),
+			headers:         make([]Header, 0, 8),
+			params:          make([]rtr.Parameter, 0, 8),
+			multipartMaxMem: s.options.MultipartMaxMemory,
 		},
 		response: response{
 			body:    make([]byte, 0, 1024),

--- a/Server_test.go
+++ b/Server_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 
@@ -321,6 +323,69 @@ func TestEarlyClose(t *testing.T) {
 	}()
 
 	_ = s.Run()
+}
+
+// TestStaticFilesPathTraversal asserts that StaticFiles refuses requests whose
+// wildcard path contains `..` segments — directly or percent-encoded — and
+// that legitimate requests still resolve. Regression guard: prior to the
+// containment fix, `filepath.Join` would normalize `..` and let a request
+// like /static/../sentinel.txt escape the configured root.
+func TestStaticFilesPathTraversal(t *testing.T) {
+	// StaticFiles serves relative to the process CWD (it reads via "." + path),
+	// so we hop CWD into a temp dir for the duration of the test and restore
+	// it on exit. Using a sibling layout: <tmp>/safe/ is the served root,
+	// <tmp>/secret.txt is the off-root sentinel that must remain unreachable.
+	origWD, err := os.Getwd()
+	assert.Nil(t, err)
+	tmp := t.TempDir()
+	assert.Nil(t, os.Chdir(tmp))
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	const allowedBody = "ok-allowed"
+	const secretBody = "off-root-secret"
+	assert.Nil(t, os.MkdirAll(filepath.Join(tmp, "safe"), 0o755))
+	assert.Nil(t, os.WriteFile(filepath.Join(tmp, "safe", "allowed.txt"),
+		[]byte(allowedBody), 0o644))
+	assert.Nil(t, os.WriteFile(filepath.Join(tmp, "secret.txt"),
+		[]byte(secretBody), 0o644))
+
+	s := rweb.NewServer()
+	// Strip the "/static" prefix and serve from "./safe" relative to CWD.
+	s.StaticFiles("/static/", "safe", 1)
+
+	// Happy path: legit request resolves and returns content.
+	resp := s.Request(consts.MethodGet, "/static/allowed.txt", nil, nil)
+	assert.Equal(t, int(200), int(resp.Status()))
+	assert.Equal(t, allowedBody, string(resp.Body()))
+
+	// Each of these traversal attempts must NOT return secret content.
+	// We accept any non-200 status (404 is what the guard returns) and
+	// require the body to never contain the off-root sentinel.
+	traversals := []string{
+		"/static/../secret.txt",
+		"/static/%2E%2E/secret.txt",
+		"/static/%2e%2e/secret.txt",
+		"/static/foo/../../secret.txt",
+		"/static/%2e%2e%2fsecret.txt",
+		// NUL byte truncation: some C-string-based filesystems would treat
+		// "allowed.txt\x00.evil" as "allowed.txt". We reject NUL outright.
+		"/static/allowed.txt%00.evil",
+		// Double-slash: attempts to make filepath.Join collapse into an
+		// absolute lookup. Containment check must still catch it.
+		"/static//etc/passwd",
+		// Absolute-path injection (rare but possible if a router decoded the
+		// wildcard into a path that begins with `/`).
+		"/static/%2fetc/passwd",
+	}
+	for _, url := range traversals {
+		r := s.Request(consts.MethodGet, url, nil, nil)
+		if int(r.Status()) == 200 {
+			t.Errorf("traversal %q unexpectedly succeeded with 200", url)
+		}
+		if bytes.Contains(r.Body(), []byte(secretBody)) {
+			t.Errorf("traversal %q leaked off-root content", url)
+		}
+	}
 }
 
 func TestUnavailablePort(t *testing.T) {

--- a/ai_docs/claude_sessions/2026-0509-2225-pre-tag-low-hanging-fruit-sweep.md
+++ b/ai_docs/claude_sessions/2026-0509-2225-pre-tag-low-hanging-fruit-sweep.md
@@ -1,0 +1,90 @@
+# Pre-tag low-hanging-fruit sweep — rweb
+
+**Date:** 2026-05-09 22:25
+**Session ID:** f0448dd7-19b1-42e7-8605-c00cfc789aba
+**Branch:** master
+**Starting commit:** 3e8d8f0 (Merge PR #29 — additional MIME types)
+**Last tag:** v0.1.26
+
+## Goal
+
+User intended to push a new tag for the recent MIME-type fixes and asked to first sweep for low-hanging fruit (bugs or features) in rweb that could ship in the same tag.
+
+## Approach
+
+1. Three Explore agents in parallel:
+   - Bugs / TODOs / dead code audit
+   - Missing-feature gap analysis vs Echo/Gin/Fiber
+   - SSE / WebSocket / security audit
+2. Verified each finding by reading source directly (agents over-claimed in places — for example a "race condition on `listener.Close()`" turned out to be a benign redundant close; "proxy Host header forwarding" is intentional, not a bug).
+3. Asked user to scope the in-scope items via AskUserQuestion. User selected 7 of 8 candidates; declined re-enabling the `ParseMultipartForm` auto-call in `GetFormFile`.
+4. Wrote plan at `~/.claude/plans/snappy-coalescing-bear.md`, exited plan mode, implemented.
+
+## Items shipped
+
+### Bugs / hardening
+1. **Path traversal in `StaticFiles`** (`Server.go`)
+   - Wildcard param was joined into the FS path with no `Clean`/`Rel` guard. `GET /static/../../etc/passwd` would escape the configured `targetDir` since `filepath.Join` *normalizes* `..` rather than rejecting.
+   - Fix: percent-unescape the wildcard, reject `..` segments and NUL bytes, then verify candidate is under root via `filepath.Abs` + `filepath.Rel`. Returns 404 (not 403) so off-root existence isn't probeable.
+2. **SSE disconnect-detector goroutine leak** (`Server.go::sendSSE`)
+   - The `go func(){ ctx.conn.Read(buf) }()` only unblocks on *client* close. On every other exit path (events channel close, `"close"` sentinel string, write error) the goroutine stayed parked on a conn the framework had stopped tracking.
+   - Fix: deferred `ctx.conn.SetReadDeadline(time.Unix(1,0))` + `sync.WaitGroup.Wait()` ensures the inner goroutine retires before `sendSSE` returns. Defer ordering: registered after the existing `sseCleanup` defer, so it runs *before* cleanup (LIFO), guaranteeing the reader is gone before any cleanup callbacks fire.
+3. **`X-Content-Type-Options: nosniff` on file responses** (`send.go::setFileHeaders`)
+   - One-line addition. Defense-in-depth for user-controlled static content.
+
+### Features added to the public API
+4. **`Context.NoContent() error`** — 204 helper.
+5. **`Request.GetFormFiles(key) ([]*multipart.FileHeader, error)`** — multi-file uploads. Existing `GetFormFile` only returned the first file under a key.
+6. **`Context.ClientIP() string`** — `X-Forwarded-For` (first entry) → `X-Real-IP` → `RemoteAddr` host portion. Documented in interface as untrusted-by-default.
+7. **`Context.BasicAuth() (user, pass string, ok bool)`** — RFC 7617 parsing. Case-insensitive `Basic` prefix; preserves colons in password; only returns `ok` when header is present, well-formed, base64-decodes, and contains `:`.
+
+## Verification methodology that proved valuable
+
+- **Adversarial test for SSE leak:** wrote `TestSSESenderGoroutineExitsOnChannelClose` first using `runtime.NumGoroutine()`, but the test passed even with the fix reverted because the test client's still-open conn parks `handleConnection` separately — the +1 from the leaked reader was hidden in the noise. Switched to scanning every goroutine's stack trace with `runtime.Stack(buf, true)` and matching on `rweb.(*Server).sendSSE.func` + an in-flight Read frame. Verified by temporarily reverting the fix — test correctly identified the leaked goroutine parked at `Server.go:1057`. Then restored the fix; test passes again.
+
+## Coverage gap audit (round 2)
+
+User asked for an honest gap audit. Identified five gaps; closed four, deferred one with rationale:
+
+| Gap | Resolution |
+|---|---|
+| `GetFormFiles` had **zero** test coverage | Added `TestGetFormFiles` (real-HTTP multipart upload: 3 files under same key + decoy under different key, asserts count/names/contents) and `TestGetFormFilesNotPresent` (missing-key error path). The synthetic `s.Request()` doesn't pipe the body parameter through to the multipart parser, so this had to be a real-server test. |
+| SSE leak fix only tested via channel-close exit | Added `TestSSESenderGoroutineExitsOnCloseSentinel` for the `"close"` string sentinel exit path. |
+| Path traversal table missed NUL byte / double-slash / absolute-path-injection | Added `/static/allowed.txt%00.evil`, `/static//etc/passwd`, `/static/%2fetc/passwd` to the existing table. |
+| `ClientIP` `RemoteAddr` fallback untested (synthetic `Request` has no conn) | Added `TestClientIPRemoteAddrFallback` against real listener; asserts loopback IP returned without port. |
+| Symlink-following in `StaticFiles` | Deferred. Defending requires `EvalSymlinks` per request — perf cost users should opt into. Out of scope for tag-prep. |
+
+Two other items deliberately *not* added:
+- SSE write-error exit path test — would require whitebox + faulty `respWriter` injection. The deferred cleanup covers all return paths uniformly; the two we tested exercise the same `defer`.
+- `NoContent` body-already-written test — my impl mirrors Echo/Gin (no body clearing). API-design choice, not a bug.
+
+## Final state
+
+- 9 files modified, 727 insertions, 4 deletions.
+- `go vet ./...` clean.
+- `go test ./...` and `go test -race ./...` green.
+- Ready to tag (suggested `v0.1.27`).
+
+## Files touched
+
+- `Server.go` — path-traversal guard in `StaticFiles`; SSE goroutine cleanup in `sendSSE`. Added `slices`, `time` imports.
+- `Request.go` — `GetFormFiles` impl and `ItfRequest` interface entry.
+- `Context.go` — `NoContent`, `ClientIP`, `BasicAuth` (interface + impl). Added `encoding/base64`, `consts` imports.
+- `send.go` — `X-Content-Type-Options: nosniff` in `setFileHeaders`.
+- `Server_test.go` — `TestStaticFilesPathTraversal` (8 traversal variants + happy path).
+- `Request_test.go` — `TestGetFormFiles`, `TestGetFormFilesNotPresent`.
+- `Context_test.go` — `TestNoContent`, `TestClientIP` (table-driven), `TestClientIPRemoteAddrFallback`, `TestBasicAuth` (9 sub-cases).
+- `sse_test.go` — `TestSSESenderGoroutineExitsOnChannelClose`, `TestSSESenderGoroutineExitsOnCloseSentinel`.
+- `send_test.go` — added nosniff header assertion in `TestFileHeaders`.
+
+## Items rejected from scope (worth recording so we don't re-investigate)
+
+- **405 Method-Not-Allowed**: requires router to track methods-per-path. Not low-hanging; defer.
+- **`listener.Close()` "race"** (one of the agents flagged it): `defer listener.Close()` + explicit close in `Run()` is just redundant. `net.Listener.Close` is idempotent. No race.
+- **Proxy `Host` header forwarding**: intentional for transparent-proxy use case. Not a bug.
+- **`CookieConfig.EncryptionKey` is declared but unused**: real gap, but full HMAC/AES wiring is bigger than tag-prep. Defer.
+- **Re-enabling `ParseMultipartForm` auto-call in `GetFormFile`** (lines 214-216 of `Request.go`): currently commented out, forcing callers to parse manually. User declined to re-enable in this pass.
+
+## Plan file
+
+`~/.claude/plans/snappy-coalescing-bear.md` — final approved plan with implementation specifics for each in-scope item.

--- a/ai_docs/claude_sessions/2026-0509-2315-fix-multipart-form-leak.md
+++ b/ai_docs/claude_sessions/2026-0509-2315-fix-multipart-form-leak.md
@@ -1,0 +1,128 @@
+# Fix multipart form handling — cross-request data leaks and dead state
+
+- **Date:** 2026-05-09 23:15
+- **Session ID:** `e3332204-9a24-4bc0-b357-58fee397652f`
+- **Branch:** `roh/fix-some-low-hanging-fruit`
+
+## Trigger
+
+User selected lines 218–220 of `~/projs/go/pers/rweb/Request.go`:
+
+```go
+// if err := req.ParseMultipartForm(); err != nil {
+// 	return nil, nil, err
+// }
+```
+
+…and asked: "I don't remember why I commented out lines 219–221, but I seem to remember I was not happy with the way multipart form was handled in the request functions. Please take a deep dive into what is happening between multipartForm and regular form handling or anything not kosher here."
+
+## Why those lines were commented out
+
+`Server.handleRequest` already pre-parses multipart bodies eagerly at the top of request handling:
+
+```go
+// Server.go (~927)
+if bytes.HasPrefix(ctx.ContentType, consts.BytMultipartFormData) {
+    if err := ctx.request.ParseMultipartForm(); err != nil { ... }
+}
+```
+
+So calling `ParseMultipartForm` again inside `GetFormFile` was redundant on the happy path — that's why it got commented out. But it left the function fragile: any pre-parse failure was logged with `fmt.Printf` and silently swallowed. The handler then saw `req.multipartForm == nil` and got back a generic `"no multipart form data"` error, indistinguishable from a body-less request.
+
+## Deep-dive findings
+
+### 1. Cross-request data leak via `multipartForm` (real bug)
+
+`CleanupMultipartForm` called `form.RemoveAll()` (which only deletes temp files for `File` parts) but **never set `req.multipartForm = nil`**. With HTTP keep-alive the same `*context` is reused (Server.go:913 `ctx.Clean()`), so `req.multipartForm` survived across requests. `Form.Value` is a plain string-map that `RemoveAll` does not clear — so on a non-multipart follow-up request:
+
+```go
+func (req *request) FormValue(key string) string {
+    if req.multipartForm != nil {                       // <-- still non-nil!
+        if values := req.multipartForm.Value[key]; ... { // <-- prior request's data
+            return values[0]
+        }
+    }
+    return req.GetPostValue(key)
+}
+```
+
+`FormValue("foo")` on request N could return a value submitted in request N-1.
+
+### 2. Cross-request data leak via `postArgs` (real bug, mirror of #1)
+
+`Context.Clean()` reset `parsedPostArgs = false` but never reset `req.postArgs`. Then `parsePostArgs` early-returns when Content-Type isn't `application/x-www-form-urlencoded` — so a GET on the same connection reads back the previous urlencoded POST's args via `GetPostValue → PostArgs() → returns &req.postArgs`.
+
+### 3. Dead `multipartFormBoundary` field
+
+Declared at Request.go:67, never assigned, never read. `ParseMultipartForm` recomputes the boundary locally each call.
+
+### 4. Inverted `GetPostValue` interface comment
+
+```go
+// GetPostValue retrieves the value of POST param - cannot be used for non-multipart forms
+// use FormValue for multipart form values.
+```
+
+Actually `GetPostValue` is for **urlencoded** forms and **cannot** be used for multipart. The "non-" inverted the meaning.
+
+### 5. Multipart parse errors silently dropped
+
+`Server.go:929–935` logs parse errors via `Printf` and continues. The handler can't distinguish a parse failure from a missing body.
+
+### 6. Hard-coded 32 MB allocation
+
+`reader.ReadForm(32 << 20)` was a magic number with no `ServerOptions` knob.
+
+### 7. Asymmetric API surface and misleading `FormValue` doc
+
+Interface comment said `FormValue` retrieves multipart form parameter values, but the implementation also falls back to `GetPostValue` for urlencoded — handles both content types.
+
+## Fixes applied
+
+User said "fix all the issues."
+
+### `Request.go`
+
+- Removed dead `multipartFormBoundary` field.
+- Added `multipartParseErr error` field — caches parse failure so all accessors surface the same real error.
+- Added `multipartMaxMem int64` field — per-request memory cap, configurable.
+- Added `defaultMultipartMaxMemory int64 = 32 << 20` constant.
+- `ParseMultipartForm`: now properly idempotent. Caches both success (`multipartForm`) and failure (`multipartParseErr`). Uses `multipartMaxMem`, falling back to default when zero.
+- `GetFormFile`: uncommented the defensive `ParseMultipartForm` call (no-op on pre-parsed happy path, surfaces real error on failure).
+- `GetFormFiles`: same defensive call added.
+- `FormValue`: rewritten to dispatch on the **current** request's Content-Type rather than `multipartForm != nil` — this is the actual fix for the leak in #1.
+- `CleanupMultipartForm`: now nils out `multipartForm` and clears `multipartParseErr`. This is the load-bearing change.
+- Fixed inverted `GetPostValue` interface doc; clarified `FormValue` interface doc.
+
+### `Context.go`
+
+- `Clean()` now calls `ctx.request.postArgs.Reset()` in addition to clearing the `parsedPostArgs` flag — fix for #2.
+
+### `Server.go`
+
+- Added `ServerOptions.MultipartMaxMemory int64` (0 = use 32 MB default).
+- Added `WithMultipartMaxMemory(n int64) ServerOption` functional option.
+- Updated `WithOptions` to copy the new field.
+- `newContext` seeds `request.multipartMaxMem` from `s.options.MultipartMaxMemory` once at pool creation (config, not request state — never reset by Cleanup).
+
+## Verification
+
+```
+go build ./...
+go test ./...
+ok  	github.com/rohanthewiz/rweb	3.104s
+ok  	github.com/rohanthewiz/rweb/core/rtr	(cached)
+```
+
+All tests pass.
+
+## Files changed
+
+- `~/projs/go/pers/rweb/Request.go`
+- `~/projs/go/pers/rweb/Context.go`
+- `~/projs/go/pers/rweb/Server.go`
+
+## Notes for future work
+
+- Consider making multipart parsing fully **lazy** (drop the eager pre-parse in `handleRequest`). With error caching now in place, lazy would avoid the up-to-32MB allocation for handlers that don't read the form. Skipped this round to preserve backward compatibility.
+- `GetPostValue` interface doc is now correct, but the API still has overlapping responsibilities between `GetPostValue` and `FormValue`. A future cleanup could deprecate `GetPostValue` to a thin alias.

--- a/ai_docs/claude_sessions/2026-0509-2336-fix-multipart-form-state-leaks.md
+++ b/ai_docs/claude_sessions/2026-0509-2336-fix-multipart-form-state-leaks.md
@@ -1,0 +1,138 @@
+# Fix multipart/urlencoded form state leaks across keep-alive requests
+
+- **Date:** 2026-05-09 23:36
+- **Session ID:** `e3332204-9a24-4bc0-b357-58fee397652f`
+- **Branch:** `roh/fix-some-low-hanging-fruit`
+- **Supersedes:** `2026-0509-2315-fix-multipart-form-leak.md` (earlier snapshot of the same session)
+
+## Trigger
+
+User selected lines 218–220 of `~/projs/go/pers/rweb/Request.go`:
+
+```go
+// if err := req.ParseMultipartForm(); err != nil {
+// 	return nil, nil, err
+// }
+```
+
+…and asked: "I don't remember why I commented out lines 219–221, but I seem to remember I was not happy with the way multipart form was handled in the request functions. Please take a deep dive into what is happening between multipartForm and regular form handling or anything not kosher here."
+
+## Why those lines were commented out
+
+`Server.handleRequest` already eagerly pre-parses multipart bodies before any handler runs:
+
+```go
+// Server.go (~927)
+if bytes.HasPrefix(ctx.ContentType, consts.BytMultipartFormData) {
+    if err := ctx.request.ParseMultipartForm(); err != nil { ... }
+}
+```
+
+So calling `ParseMultipartForm` again inside `GetFormFile` looked redundant. But it was load-bearing: any pre-parse failure was logged with `fmt.Printf` and silently swallowed, and the handler then saw `req.multipartForm == nil` and got back a generic `"no multipart form data"` error — indistinguishable from a body-less request.
+
+## Bugs found
+
+The deep dive turned up **five** real bugs, all in the same shape: state on the request struct survived `Context.Clean()` and leaked into the next request on the same keep-alive connection (since contexts are pooled per-connection in `Server.handleConnection`).
+
+### 1. `multipartForm` not nil-ed in CleanupMultipartForm
+
+`form.RemoveAll()` only deletes temp files for `File` parts. `Form.Value` (a plain string-map) was preserved. Combined with `FormValue`'s pre-fix dispatch logic (`if req.multipartForm != nil`), request N+1 could read string values from request N's multipart form.
+
+### 2. `postArgs` not reset in Context.Clean
+
+`Clean()` reset `parsedPostArgs = false` but never reset `req.postArgs`. `parsePostArgs` early-returns when Content-Type isn't urlencoded, so a follow-up request with a non-form Content-Type read back the previous urlencoded POST's args via `GetPostValue → PostArgs() → returns &req.postArgs`.
+
+### 3. `ContentType []byte` cache not reset (discovered during negative validation)
+
+`req.ContentType` is populated when the `Content-Type` header is read. But `Clean()` didn't reset it. So a follow-up request that sent NO Content-Type header (e.g. a GET) inherited the previous value, silently steering `parsePostArgs` / `FormValue` / `ParseMultipartForm` down the wrong path.
+
+This bug **masked** the postArgs test from #2: with the leaked Content-Type still saying urlencoded, parsePostArgs re-entered the parse path against the empty body, which cleared postArgs as a side effect.
+
+### 4. Multipart parse errors silently swallowed
+
+`Server.go:929–935` logged parse errors via `Printf` and continued. The handler couldn't distinguish a parse failure from a missing body.
+
+### 5. Hard-coded 32 MB ceiling, dead `multipartFormBoundary` field, inverted/misleading comments
+
+- `reader.ReadForm(32 << 20)` — magic number, no `ServerOptions` knob.
+- `multipartFormBoundary` declared, never written or read.
+- `GetPostValue` interface comment said "non-multipart" where it should have said "multipart".
+- `FormValue` interface comment claimed multipart-only when it actually handles both content types.
+
+## Fixes applied
+
+### `Request.go`
+
+- Removed dead `multipartFormBoundary` field.
+- Added `multipartParseErr error` — caches parse failures; subsequent calls (from `GetFormFile` / `GetFormFiles` / `FormValue`) get the same real error rather than a generic sentinel.
+- Added `multipartMaxMem int64` — per-request memory cap, configurable via `ServerOptions.MultipartMaxMemory`.
+- Added `defaultMultipartMaxMemory int64 = 32 << 20` const.
+- `ParseMultipartForm` now properly idempotent: caches both success (`multipartForm`) and failure (`multipartParseErr`).
+- `GetFormFile`: uncommented the defensive `ParseMultipartForm` call.
+- `GetFormFiles`: same defensive call added.
+- `FormValue`: rewritten to dispatch on the **current** request's Content-Type rather than `multipartForm != nil`. This is part of the layered fix for #1.
+- `CleanupMultipartForm`: now nils out `multipartForm` and clears `multipartParseErr` (the load-bearing change for #1).
+- Fixed inverted `GetPostValue` interface doc; clarified `FormValue` interface doc.
+
+### `Context.go`
+
+- `Clean()` now also calls `ctx.request.postArgs.Reset()` (fix for #2).
+- `Clean()` now also sets `ctx.request.ContentType = nil` (fix for #3).
+
+### `Server.go`
+
+- Added `ServerOptions.MultipartMaxMemory int64` (0 = use 32 MB default).
+- Added `WithMultipartMaxMemory(n int64) ServerOption` functional option.
+- Updated `WithOptions` to copy the new field.
+- `newContext` seeds `request.multipartMaxMem` from `s.options.MultipartMaxMemory` once at pool creation (config, not request state — never reset by Cleanup).
+
+## Regression tests added (`Request_leak_test.go`)
+
+User asked for edge-case coverage. The existing test suite had zero coverage for the cross-request leaks — without regression tests these bugs could silently return.
+
+All five tests use a shared `*http.Transport` with `MaxConnsPerHost: 1` to force connection reuse, and **assert reuse via `httptrace.GotConn{Reused: true}`** — without that assertion, a test that accidentally landed on a fresh connection would silently pass.
+
+| Test | Target fix | Negative-validation result |
+|---|---|---|
+| `TestMultipartDoesNotLeakIntoFollowingGet` | FormValue Content-Type dispatch + Cleanup nil-out (defense in depth) | passes with both fixes |
+| `TestMultipartDoesNotLeakIntoFollowingMultipart` | `multipartForm = nil` in CleanupMultipartForm | reverting fix → `FormValue('leaktest') on request 2 = "request-one" (want empty)` |
+| `TestPostArgsDoNotLeakIntoFollowingNonFormPost` | `postArgs.Reset()` in Clean | reverting fix → `GetPostValue('leaktest') on JSON POST = "request-one" (want empty)` |
+| `TestMalformedMultipartSurfacesParseError` | Uncomment + error caching in GetFormFile | reverting fix → `GetFormFile masked the real parse error with the generic sentinel: "no multipart form data"` |
+| `TestContentTypeDoesNotLeakAcrossRequests` | `ContentType = nil` in Clean (the bug discovered DURING test validation) | reverting fix → `ContentType leaked: GetFormFile saw "multipart: NextPart: EOF"` |
+
+### Test design notes worth keeping
+
+- **Test 3 sends a JSON POST as request 2, not a GET.** Initial draft used a GET, but with the ContentType leak (#3) still present, parsePostArgs would re-enter the parse path against the empty body and clear postArgs as a side-effect, hiding the bug. A JSON POST has Content-Type `application/json` which forces parsePostArgs to early-return cleanly, exposing the underlying postArgs leak.
+- **Test 4 uses raw `net.Conn`.** Go's `net/http` auto-adds a boundary parameter to multipart Content-Types, which would prevent us from constructing the malformed-Content-Type case.
+- **`t.Fatal` doesn't work from goroutines** (calls `runtime.Goexit` only on the calling goroutine). All tests use `t.Errorf` + `return` instead.
+
+## Verification
+
+```
+go test ./...
+ok  	github.com/rohanthewiz/rweb	5.000s
+ok  	github.com/rohanthewiz/rweb/core/rtr	(cached)
+```
+
+All tests pass with all fixes restored. Each regression test was independently verified to FAIL when its target fix was reverted, then the fix was restored.
+
+## Files changed
+
+- `~/projs/go/pers/rweb/Request.go`
+- `~/projs/go/pers/rweb/Context.go`
+- `~/projs/go/pers/rweb/Server.go`
+- `~/projs/go/pers/rweb/Request_leak_test.go` *(new)*
+
+## Lessons / takeaways
+
+1. **Negative-validation is non-optional for regression tests.** Three of the four originally-passing tests had subtle issues that only surfaced when each fix was reverted. One of them (test 3) found an entirely *new* bug (#3, the ContentType leak).
+
+2. **Per-connection context pooling means every cached field on the request struct is a potential cross-request leak.** Audit checklist: when adding a cached field on `request`, also add a reset in `Context.Clean()`. Worth grep-auditing the rest of the struct (e.g. `query`, `path`, `method`, `host`, `scheme` are reset elsewhere; `params` is reset; `headers` and `body` are reset).
+
+3. **The eager multipart pre-parse in `Server.go` is still 32 MB per request even when handlers don't read the form.** `WithMultipartMaxMemory` lets users tune it down per-server. A future improvement would be to make multipart parsing fully lazy on first `GetFormFile`/`FormValue` call (the body is already buffered, so this is feasible) — that would also let unrelated handlers skip the cost entirely.
+
+## Notes for next time
+
+- Consider also resetting `multipartMaxMem` in `Clean()`? No — it's config, not request state, and the comment in `newContext` documents that.
+- The `_ = context.Background` compile-time guard at the bottom of `Request_leak_test.go` is a vestige from an earlier draft when `context` was imported but unused after a refactor; it can be removed if `httptrace.WithClientTrace` calls keep `context` in active use (they do).
+- `Cookie_test.go` and `args.go` / `bytesconv.go` carry pre-existing lint hints (`unusedwrite`, `unusedfunc`, `efaceany`) that are unrelated to this work.

--- a/send.go
+++ b/send.go
@@ -186,6 +186,10 @@ func setFileHeaders(ctx Context, filename string, modTime time.Time) {
 		ctx.Response().SetHeader(consts.HeaderContentType, mimeType)
 	}
 
+	// Defense-in-depth: keep browsers from MIME-sniffing user-controlled static
+	// content into a script type even when our Content-Type is exactly right.
+	ctx.Response().SetHeader("X-Content-Type-Options", "nosniff")
+
 	// Set Date header (RFC 7231 requirement for origin servers)
 	ctx.Response().SetHeader(consts.HeaderDate, time.Now().UTC().Format(time.RFC1123))
 

--- a/send_test.go
+++ b/send_test.go
@@ -191,6 +191,10 @@ func TestFileHeaders(t *testing.T) {
 			// Check Date header is present (RFC 7231 requirement)
 			assert.NotEqual(t, response.Header("Date"), "")
 
+			// Check nosniff is set on every file response (defense-in-depth
+			// against MIME sniffing user-controlled static content).
+			assert.Equal(t, response.Header("X-Content-Type-Options"), "nosniff")
+
 			// Check download headers
 			contentDisposition := response.Header("Content-Disposition")
 			if tt.shouldHaveDownload {

--- a/sse_test.go
+++ b/sse_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -97,6 +98,174 @@ func TestSSEHandler(t *testing.T) {
 		// Test completed normally
 	case <-time.After(15 * time.Second):
 		t.Fatal("Test did not complete within timeout")
+	}
+}
+
+// TestSSESenderGoroutineExitsOnChannelClose is a regression guard for a goroutine
+// leak in sendSSE: the disconnect-detector goroutine (`go func(){ conn.Read(...) }`)
+// only unblocks when the *client* closes its side of the conn. If sendSSE returns
+// through the events-channel-closed path instead, that goroutine would otherwise
+// stay parked forever. The fix sets a past-instant ReadDeadline in a defer so the
+// goroutine unblocks deterministically. We assert by counting goroutines: the
+// post-test count must settle back to the pre-test baseline.
+func TestSSESenderGoroutineExitsOnChannelClose(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	sseDone := make(chan struct{})
+
+	// Server closes this channel itself to trigger the events-closed exit path
+	// (NOT the connGone path). The client must therefore stay connected for
+	// the test to actually exercise the leak scenario.
+	eventsChan := make(chan any, 1)
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	s.Get("/events", func(ctx rweb.Context) error {
+		defer close(sseDone)
+		return ctx.SetSSE(eventsChan, "test-events")
+	})
+
+	serverDone := make(chan struct{})
+	go func() {
+		_ = s.Run()
+		close(serverDone)
+	}()
+	defer func() {
+		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		<-serverDone
+	}()
+
+	<-readyChan
+
+	// Capture baseline AFTER server has spun up its accept loop, BEFORE we
+	// open the SSE conn (which forks the disconnect-detector goroutine).
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	base := runtime.NumGoroutine()
+
+	addr := fmt.Sprintf("127.0.0.1:%s", s.GetListenPort())
+	conn, err := net.Dial("tcp", addr)
+	assert.Nil(t, err)
+	defer conn.Close() // client stays connected through the channel-close path
+
+	reqStr := fmt.Sprintf("GET /events HTTP/1.1\r\nHost: %s\r\nAccept: text/event-stream\r\n\r\n", addr)
+	_, err = conn.Write([]byte(reqStr))
+	assert.Nil(t, err)
+
+	// Wait for the response status line so we know sendSSE has started
+	// (and the inner Read goroutine has been spawned).
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	assert.Nil(t, err)
+	assert.Equal(t, strings.Contains(statusLine, "200"), true)
+
+	// Trigger the channel-closed exit path, then wait for sendSSE to return.
+	close(eventsChan)
+	select {
+	case <-sseDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sendSSE did not return after events channel was closed")
+	}
+
+	// Give the deferred SetReadDeadline + WaitGroup.Wait a moment to retire
+	// the inner reader goroutine and let the runtime account for it.
+	time.Sleep(200 * time.Millisecond)
+	runtime.GC()
+
+	// Goroutine *count* alone is too coarse here — the test client's still-open
+	// conn keeps handleConnection parked, hiding the +1 from a leaked reader.
+	// Instead, dump every goroutine's stack and look for one whose frames
+	// include the reader closure inside sendSSE. That frame is unique to the
+	// leak: no other code path produces a goroutine sitting in `sendSSE.funcN`.
+	buf := make([]byte, 1<<16)
+	n := runtime.Stack(buf, true)
+	stacks := string(buf[:n])
+	for _, gstack := range strings.Split(stacks, "\n\n") {
+		if strings.Contains(gstack, "rweb.(*Server).sendSSE.func") &&
+			(strings.Contains(gstack, "internal/poll") ||
+				strings.Contains(gstack, "net.(*conn).Read")) {
+			t.Logf("leaked reader goroutine stack:\n%s", gstack)
+			t.Errorf("sendSSE reader goroutine still parked after channel-close exit (baseline=%d, now=%d)",
+				base, runtime.NumGoroutine())
+			return
+		}
+	}
+}
+
+// TestSSESenderGoroutineExitsOnCloseSentinel is a second exit-path guard for
+// the sendSSE goroutine cleanup: when the events channel sends the literal
+// string "close", sendSSE returns *without* the channel being closed and
+// without the client disconnecting. Under the bug, the inner Read goroutine
+// would still be parked. Under the fix, the deferred SetReadDeadline retires
+// it on every return path including this one.
+func TestSSESenderGoroutineExitsOnCloseSentinel(t *testing.T) {
+	readyChan := make(chan struct{}, 1)
+	sseDone := make(chan struct{})
+
+	eventsChan := make(chan any, 1)
+
+	s := rweb.NewServer(rweb.ServerOptions{
+		ReadyChan: readyChan,
+		Address:   "localhost:",
+	})
+
+	s.Get("/events", func(ctx rweb.Context) error {
+		defer close(sseDone)
+		return ctx.SetSSE(eventsChan, "test-events")
+	})
+
+	serverDone := make(chan struct{})
+	go func() {
+		_ = s.Run()
+		close(serverDone)
+	}()
+	defer func() {
+		syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+		<-serverDone
+	}()
+
+	<-readyChan
+
+	addr := fmt.Sprintf("127.0.0.1:%s", s.GetListenPort())
+	conn, err := net.Dial("tcp", addr)
+	assert.Nil(t, err)
+	defer conn.Close()
+
+	reqStr := fmt.Sprintf("GET /events HTTP/1.1\r\nHost: %s\r\nAccept: text/event-stream\r\n\r\n", addr)
+	_, err = conn.Write([]byte(reqStr))
+	assert.Nil(t, err)
+
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	assert.Nil(t, err)
+	assert.Equal(t, strings.Contains(statusLine, "200"), true)
+
+	// Trigger the close-sentinel exit (NOT a close(eventsChan)). The handler
+	// recognizes the literal string "close" and returns from the event loop.
+	eventsChan <- "close"
+
+	select {
+	case <-sseDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sendSSE did not return after close-sentinel event")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	runtime.GC()
+
+	buf := make([]byte, 1<<16)
+	n := runtime.Stack(buf, true)
+	stacks := string(buf[:n])
+	for _, gstack := range strings.Split(stacks, "\n\n") {
+		if strings.Contains(gstack, "rweb.(*Server).sendSSE.func") &&
+			(strings.Contains(gstack, "internal/poll") ||
+				strings.Contains(gstack, "net.(*conn).Read")) {
+			t.Logf("leaked reader goroutine stack:\n%s", gstack)
+			t.Errorf("sendSSE reader goroutine still parked after close-sentinel exit")
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Five state-leak bugs in form handling, all rooted in the fact that contexts are pooled per *connection*: consecutive requests on a keep-alive connection share a `*context`, and any cached request state that survived `Context.Clean()` leaked into the next request.

## Bugs fixed

- **`multipartForm` not nil-ed in `CleanupMultipartForm`.** `RemoveAll()` only deletes temp files for `File` parts; `Form.Value` (a string-map) was preserved. With the prior `multipartForm != nil` check inside `FormValue`, request N+1 could read string values from request N's multipart form.
- **`postArgs` not reset in `Context.Clean`.** The `parsedPostArgs` flag was reset but `req.postArgs` was not; `parsePostArgs` early-returns on Content-Type mismatch, so a follow-up non-form request read stale args via `GetPostValue → PostArgs() → &req.postArgs`.
- **`req.ContentType` cache not reset** *(discovered during regression-test negative-validation)*. A follow-up request that sent no `Content-Type` header inherited the previous value, silently steering `parsePostArgs` / `FormValue` / `ParseMultipartForm` down the wrong path. This was masking the postArgs test until uncovered.
- **`ParseMultipartForm` errors silently dropped.** Server pre-parse logged via `Printf` and continued; handler then saw generic `"no multipart form data"`. Added `multipartParseErr` cache so `GetFormFile` / `GetFormFiles` / `FormValue` surface the real error. Uncommented the defensive `ParseMultipartForm` call inside `GetFormFile` (and added one in `GetFormFiles`).
- **Hard-coded 32 MB `ReadForm` limit.** Added `ServerOptions.MultipartMaxMemory` + `WithMultipartMaxMemory` option; defaults to 32 MB.

## Other cleanups

- Removed dead `multipartFormBoundary` field.
- Fixed inverted `GetPostValue` interface comment (it said "non-multipart" where it meant "multipart"); clarified that `FormValue` handles both content types.
- `FormValue` now dispatches by the current request's `Content-Type` rather than `multipartForm != nil` — the original source of bug #1.

## Tests

New file `Request_leak_test.go` adds five regression tests. All assert connection reuse via `httptrace.GotConn{Reused: true}` so a test that accidentally lands on a fresh connection fails loudly rather than passing vacuously. Each test was independently verified to **fail** when its target fix was reverted, then the fix was restored.

| Test | Pins |
|---|---|
| `TestMultipartDoesNotLeakIntoFollowingGet` | FormValue Content-Type dispatch + Cleanup nil-out (defense-in-depth) |
| `TestMultipartDoesNotLeakIntoFollowingMultipart` | `multipartForm = nil` in CleanupMultipartForm |
| `TestPostArgsDoNotLeakIntoFollowingNonFormPost` | `postArgs.Reset()` in Clean (uses a JSON POST as request 2 to force parsePostArgs early-return — a GET would have its empty body re-parsed and mask the bug) |
| `TestMalformedMultipartSurfacesParseError` | GetFormFile uncomment + error caching |
| `TestContentTypeDoesNotLeakAcrossRequests` | `ContentType = nil` reset |

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green
- [x] Each new regression test verified to fail when its corresponding fix is reverted
- [ ] CI green